### PR TITLE
chore: update log file paths and refine .gitignore entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@ target/
 .sts4-cache
 
 ### IntelliJ IDEA ###
-.idea
+.idea/
 *.iws
 *.iml
 *.ipr
@@ -31,5 +31,7 @@ build/
 
 ### VS Code ###
 .vscode/
-db-data
-logs
+
+### Logs ###
+.logs/
+db-data/

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -37,7 +37,7 @@
     </root>
 
     <springProfile name="dev">
-        <looger name="ROOT" level="DEBUG"/>
+        <logger name="ROOT" level="INFO"/>
         <logger name="br.edu.ufpel" level="DEBUG"/>
     </springProfile>
 </configuration>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <configuration>
 
-    <property name="LOG_FILE" value="logs/roka-moka.log"/>
-    <property name="FILE_NAME_PATTERN" value="logs/roka-moka"/>
+    <property name="LOG_FILE" value=".logs/roka-moka.log"/>
+    <property name="FILE_NAME_PATTERN" value=".logs/roka-moka"/>
 
     <!--Console Appender with Colors-->
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">


### PR DESCRIPTION
The change updates the log file paths to include a leading dot, which indicates a switch to using hidden directories for log storage.

* [`src/main/resources/logback-spring.xml`](diffhunk://#diff-f911d4d4e27a3c60b181c0750a6da50cbc652d231c9629d13a3e86456d219c56L4-R5): Updated the `LOG_FILE` and `FILE_NAME_PATTERN` properties to use hidden directories by adding a leading dot to the paths.