### PR TITLE
[BackEnd] Device CRUD

### DIFF
--- a/src/main/java/br/edu/ufpel/rokamoka/core/Device.java
+++ b/src/main/java/br/edu/ufpel/rokamoka/core/Device.java
@@ -2,7 +2,7 @@ package br.edu.ufpel.rokamoka.core;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.ForeignKey;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -25,7 +25,7 @@ import java.util.Objects;
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
-@Table(name = "dispostivo")
+@Table(name = "dispositivo")
 public class Device {
 
     @Id
@@ -34,8 +34,8 @@ public class Device {
 
     @Column(nullable = false) private String deviceId;
 
-    @ManyToOne
-    @JoinColumn(name = "user_id", foreignKey = @ForeignKey(name = "fk_usuario"))
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
     private User user;
 
     @Override

--- a/src/main/java/br/edu/ufpel/rokamoka/repository/DeviceRepository.java
+++ b/src/main/java/br/edu/ufpel/rokamoka/repository/DeviceRepository.java
@@ -1,0 +1,7 @@
+package br.edu.ufpel.rokamoka.repository;
+
+import br.edu.ufpel.rokamoka.core.Device;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DeviceRepository extends JpaRepository<Device, Long> {
+}

--- a/src/main/java/br/edu/ufpel/rokamoka/service/device/DeviceService.java
+++ b/src/main/java/br/edu/ufpel/rokamoka/service/device/DeviceService.java
@@ -1,0 +1,36 @@
+package br.edu.ufpel.rokamoka.service.device;
+
+import br.edu.ufpel.rokamoka.core.Device;
+import br.edu.ufpel.rokamoka.core.User;
+import br.edu.ufpel.rokamoka.repository.DeviceRepository;
+import jakarta.validation.constraints.NotBlank;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.validation.annotation.Validated;
+
+/**
+ * Service implementation of the {@link IDeviceService} interface for managing operations on the {@link Device}
+ * resource.
+ *
+ * @author MauricioMucci
+ * @see DeviceRepository
+ */
+@Slf4j
+@Service
+@Validated
+@RequiredArgsConstructor
+public class DeviceService implements IDeviceService {
+
+    private final DeviceRepository deviceRepository;
+
+    @Override
+    public Device save(@NotBlank String deviceId, User user) {
+        log.info("Salvando [{}] para o [{}] informado", Device.class.getSimpleName(), user);
+        var device = Device.builder()
+                .deviceId(deviceId)
+                .user(user)
+                .build();
+        return this.deviceRepository.save(device);
+    }
+}

--- a/src/main/java/br/edu/ufpel/rokamoka/service/device/IDeviceService.java
+++ b/src/main/java/br/edu/ufpel/rokamoka/service/device/IDeviceService.java
@@ -1,0 +1,16 @@
+package br.edu.ufpel.rokamoka.service.device;
+
+import br.edu.ufpel.rokamoka.core.Device;
+import br.edu.ufpel.rokamoka.core.User;
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * Service interface for managing and retrieving information related to {@link Device}.
+ *
+ * @author MauricioMucci
+ * @see DeviceService
+ */
+public interface IDeviceService {
+
+    Device save(@NotBlank String deviceId, User user);
+}

--- a/src/main/java/br/edu/ufpel/rokamoka/service/user/IUserService.java
+++ b/src/main/java/br/edu/ufpel/rokamoka/service/user/IUserService.java
@@ -12,9 +12,13 @@ import br.edu.ufpel.rokamoka.exceptions.RokaMokaContentDuplicatedException;
 import br.edu.ufpel.rokamoka.exceptions.RokaMokaContentNotFoundException;
 import br.edu.ufpel.rokamoka.exceptions.RokaMokaForbiddenException;
 import jakarta.validation.Valid;
-import org.springframework.validation.annotation.Validated;
 
-@Validated
+/**
+ * Service interface for managing and retrieving information related to {@link User}.
+ *
+ * @author MauricioMucci
+ * @see UserService
+ */
 public interface IUserService {
 
     UserAuthDTO createNormalUser(@Valid UserBasicDTO userDTO) throws RokaMokaContentDuplicatedException;


### PR DESCRIPTION
[Device CRUD](https://trello.com/c/cUEBHd2w)

### Updates to the `Device` entity:

* Corrected the table name from "dispostivo" to "dispositivo" in the `@Table` annotation in `Device`.
* Added lazy fetching (`FetchType.LAZY`) to the `@ManyToOne` association between `Device` and `User`, and removed the explicit `ForeignKey` annotation.

### Device repository and service implementation:

* Created `DeviceRepository` to enable database operations for the `Device` entity.
* Added `DeviceService` and `IDeviceService` to encapsulate business logic for `Device` management, including a `save` method for persisting devices. [[1]](diffhunk://#diff-a87dbe8fe2a1442ef9e31d37611afb3490abf2d470932b16c261d4cebfd0e573R1-R36) [[2]](diffhunk://#diff-dec3aecbecc67f4ea93f0e3fe94c95f0fa53b58cd6e4edccdba3e9a49c8eb009R1-R16)

### Integration of device management into `UserService`:

* Injected `IDeviceService` into `UserService` and added device handling when creating normal, anonymous, and researcher users. This includes saving the user's device information if provided. [[1]](diffhunk://#diff-0a33043c5869bcefb396592f6d281a29ac057fde82f27c3a11178f0275a6de89R22-R27) [[2]](diffhunk://#diff-0a33043c5869bcefb396592f6d281a29ac057fde82f27c3a11178f0275a6de89R79) [[3]](diffhunk://#diff-0a33043c5869bcefb396592f6d281a29ac057fde82f27c3a11178f0275a6de89L121-R110) [[4]](diffhunk://#diff-0a33043c5869bcefb396592f6d281a29ac057fde82f27c3a11178f0275a6de89R196-R208)
* Added a private helper method `saveUserDevice` in `UserService` to streamline device saving logic.