### PR TITLE
feat(config): setup environment-specific configs for dev and prod

### DIFF
--- a/.env
+++ b/.env
@@ -6,6 +6,7 @@ DB_PORT=5432 # porta padrão do postgres
 DB_PORT_EXPOSE=5432 # porta que será exposta no container
 
 # Informações da aplicação
+SPRING_PROFILE=prod
 SERVER_PORT=8080 # porta padrão da aplicação
 SERVER_PORT_EXPOSE=8081 # porta que será exposta no container
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       broker:
         condition: service_healthy
     environment:
+      SPRING_PROFILES_ACTIVE: ${SPRING_PROFILE:-dev}
       SPRING_DATASOURCE_URL: jdbc:postgresql://db:${DB_PORT}/${DB_NAME}
       SPRING_DATASOURCE_USERNAME: ${DB_USER}
       SPRING_DATASOURCE_PASSWORD: ${DB_PASSWORD}
@@ -21,6 +22,8 @@ services:
       SPRING_RABBITMQ_CONNECTION_TIMEOUT: ${RABBITMQ_CONNECTION_TIMEOUT:-30000}
     ports:
       - "${APP_PORT_EXPOSE:-8080}:8080"
+    volumes:
+      - app-logs:/app/logs
     networks:
       - hoka-moka-network
 
@@ -65,6 +68,8 @@ services:
 volumes:
   db-data:
     name: rokamoka-db
+  app-logs:
+    name: rokamoka-logs
 
 networks:
   hoka-moka-network:

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,0 +1,67 @@
+spring:
+
+  application:
+    name: roka-moka-dev
+
+  datasource:
+    # URL do banco de dados, configurável via variável de ambiente. Default: localhost.
+    url: ${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/RokaMokaDb}
+
+    # Credenciais do banco, também configuráveis via env.
+    username: ${SPRING_DATASOURCE_USERNAME:rokamoka}
+    password: ${SPRING_DATASOURCE_PASSWORD:teste123}
+
+    driver-class-name: org.postgresql.Driver
+    type: com.zaxxer.hikari.HikariDataSource
+
+    hikari:
+      # Nome do pool para identificar logs
+      pool-name: HikariCP-Pool
+
+      # Máximo de conexões simultâneas no pool
+      maximum-pool-size: ${DB_MAX_POOL_SIZE:10}
+
+      # Mínimo de conexões inativas mantidas
+      minimum-idle: ${DB_MIN_IDLE:5}
+
+      # Tempo máximo que uma conexão pode ficar ociosa (em ms)
+      idle-timeout: ${DB_IDLE_TIMEOUT:180000} # 3 minutos
+
+      # Tempo máximo de vida de uma conexão (em ms)
+      max-lifetime: ${DB_MAX_LIFETIME:900000} # 15 minutos
+
+      # Tempo máximo de espera por uma conexão do pool (em ms)
+      connection-timeout: ${DB_CONNECTION_TIMEOUT:3000} # 3 segundos
+
+      # Tempo para validação da conexão (em ms)
+      validation-timeout: ${DB_VALIDATION_TIMEOUT:5000} # 5 segundos
+
+  jpa:
+    hibernate:
+      # Define se o Hibernate deve criar/atualizar o schema. Ideal manter como "none" em produção.
+      ddl-auto: ${JPA_DDL_AUTO:none}
+    open-in-view: false
+    properties:
+      hibernate:
+        format_sql: true
+    show-sql: false
+
+  rabbitmq:
+    host: ${SPRING_RABBITMQ_HOST:localhost}
+    port: ${SPRING_RABBITMQ_PORT:5672}
+    username: ${SPRING_RABBITMQ_USERNAME:rokamoka}
+    password: ${SPRING_RABBITMQ_PASSWORD:teste123}
+    connection-timeout: ${SPRING_RABBITMQ_CONNECTION_TIMEOUT:30000}
+
+jwt:
+  private:
+    key: classpath:app.key
+  public:
+    key: classpath:app.pub
+
+## CUSTOM CONFIGURATIONS
+broker:
+  exchange:
+    emblems: emblems.v1
+  queue:
+    collect-emblem: emblems.v1.collect

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,67 @@
+spring:
+
+  application:
+    name: roka-moka-prod
+
+  datasource:
+    # URL do banco de dados, configurável via variável de ambiente. Default: localhost.
+    url: ${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/RokaMokaDb}
+
+    # Credenciais do banco, também configuráveis via env.
+    username: ${SPRING_DATASOURCE_USERNAME:rokamoka}
+    password: ${SPRING_DATASOURCE_PASSWORD:teste123}
+
+    driver-class-name: org.postgresql.Driver
+    type: com.zaxxer.hikari.HikariDataSource
+
+    hikari:
+      # Nome do pool para identificar logs
+      pool-name: HikariCP-Pool
+
+      # Máximo de conexões simultâneas no pool
+      maximum-pool-size: ${DB_MAX_POOL_SIZE:10}
+
+      # Mínimo de conexões inativas mantidas
+      minimum-idle: ${DB_MIN_IDLE:5}
+
+      # Tempo máximo que uma conexão pode ficar ociosa (em ms)
+      idle-timeout: ${DB_IDLE_TIMEOUT:180000} # 3 minutos
+
+      # Tempo máximo de vida de uma conexão (em ms)
+      max-lifetime: ${DB_MAX_LIFETIME:900000} # 15 minutos
+
+      # Tempo máximo de espera por uma conexão do pool (em ms)
+      connection-timeout: ${DB_CONNECTION_TIMEOUT:3000} # 3 segundos
+
+      # Tempo para validação da conexão (em ms)
+      validation-timeout: ${DB_VALIDATION_TIMEOUT:5000} # 5 segundos
+
+  jpa:
+    hibernate:
+      # Define se o Hibernate deve criar/atualizar o schema. Ideal manter como "none" em produção.
+      ddl-auto: ${JPA_DDL_AUTO:none}
+    open-in-view: false
+    properties:
+      hibernate:
+        format_sql: true
+    show-sql: false
+
+  rabbitmq:
+    host: ${SPRING_RABBITMQ_HOST:localhost}
+    port: ${SPRING_RABBITMQ_PORT:5672}
+    username: ${SPRING_RABBITMQ_USERNAME:rokamoka}
+    password: ${SPRING_RABBITMQ_PASSWORD:teste123}
+    connection-timeout: ${SPRING_RABBITMQ_CONNECTION_TIMEOUT:30000}
+
+jwt:
+  private:
+    key: classpath:app.key
+  public:
+    key: classpath:app.pub
+
+## CUSTOM CONFIGURATIONS
+broker:
+  exchange:
+    emblems: emblems.v1
+  queue:
+    collect-emblem: emblems.v1.collect

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <configuration>
 
-    <property name="LOG_FILE" value=".logs/roka-moka.log"/>
-    <property name="FILE_NAME_PATTERN" value=".logs/roka-moka"/>
+    <property name="LOG_FILE" value="/app/logs/roka-moka.log"/>
+    <property name="FILE_NAME_PATTERN" value="/app/logs/roka-moka"/>
 
-    <!-- Console Appender with Colors -->
+    <!-- Console Appender colorido -->
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <pattern>
@@ -14,27 +14,38 @@
         </encoder>
     </appender>
 
-    <!-- File Appender with Rolling Policy -->
+    <!-- File Appender incolor -->
     <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>${LOG_FILE}</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
             <fileNamePattern>${FILE_NAME_PATTERN}.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
-            <maxHistory>5</maxHistory>
-            <maxFileSize>10MB</maxFileSize>
-            <totalSizeCap>1GB</totalSizeCap>
+            <maxHistory>30</maxHistory>
+            <maxFileSize>50MB</maxFileSize>
+            <totalSizeCap>5GB</totalSizeCap>
+            <cleanHistoryOnStart>true</cleanHistoryOnStart>
         </rollingPolicy>
         <encoder>
             <pattern>
-                %d{yyyy-MM-dd HH:mm:ss} | %-5level | [%X{username}] | [%X{executionUUID})] | %-40.40logger{39} : %m%n
+                %d{yyyy-MM-dd HH:mm:ss} | %-5level | [%X{username:-NONE}] | [%X{executionUUID:-NONE}] | %-40.40logger{39} : %m%n
             </pattern>
             <charset>UTF-8</charset>
         </encoder>
     </appender>
 
+    <!-- Appender assíncrono para melhor desempenho -->
+    <appender name="ASYNC_FILE" class="ch.qos.logback.classic.AsyncAppender">
+        <appender-ref ref="FILE"/>
+        <queueSize>2048</queueSize>
+        <discardingThreshold>0</discardingThreshold>
+        <maxFlushTime>10000</maxFlushTime>
+        <includeCallerData>true</includeCallerData>
+        <neverBlock>false</neverBlock>
+    </appender>
+
     <springProfile name="default">
         <root level="WARN">
             <appender-ref ref="CONSOLE"/>
-            <appender-ref ref="FILE"/>
+            <appender-ref ref="ASYNC_FILE"/>
         </root>
         <logger name="br.edu.ufpel" level="DEBUG"/>
         <logger name="org.springframework.security" level="DEBUG"/>
@@ -43,19 +54,16 @@
     <springProfile name="dev">
         <root level="WARN">
             <appender-ref ref="CONSOLE"/>
-            <appender-ref ref="FILE"/>
         </root>
-        <logger name="br.edu.ufpel" level="DEBUG"/>
+        <logger name="br.edu.ufpel" level="TRACE"/>
         <logger name="org.springframework.security" level="DEBUG"/>
     </springProfile>
 
     <springProfile name="prod">
         <root level="WARN">
-            <appender-ref ref="CONSOLE"/>
-            <appender-ref ref="FILE"/>
+            <appender-ref ref="ASYNC_FILE"/>
         </root>
         <logger name="br.edu.ufpel" level="INFO"/>
-        <logger name="org.springframework.security" level="DEBUG"/>
     </springProfile>
 
 </configuration>


### PR DESCRIPTION
This pull request introduces several improvements to environment configuration, logging, and application profiles for better production and development management. The changes mainly focus on enabling profile-based configuration, enhancing logging performance and retention, and ensuring correct log file persistence in containerized environments.

**Environment and Profile Management:**

* Added `SPRING_PROFILE` to `.env` and configured `SPRING_PROFILES_ACTIVE` in `docker-compose.yml` to support switching between development and production profiles. [[1]](diffhunk://#diff-e9cbb0224c4a3d23a6019ba557e0cd568c1ad5e1582ff1e335fb7d99b7a1055dR9) [[2]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R14)
* Introduced separate configuration files for development (`application-dev.yml`) and production (`application-prod.yml`), detailing datasource, RabbitMQ, JPA, JWT, and broker settings for each profile. [[1]](diffhunk://#diff-56a2780642d5bbabb1f74b4a9d6b0e33d43a672aba82f69b0d346b077d31f06dR1-R67) [[2]](diffhunk://#diff-272166538026361b7bdb5379430d7e416752e07cb68d0b1a5ff26d1899427308R1-R67)

**Logging Improvements:**

* Changed log file paths in `logback-spring.xml` to `/app/logs/` for compatibility with Docker volume mounting, and updated rolling policy to retain more logs with increased size limits. [[1]](diffhunk://#diff-f911d4d4e27a3c60b181c0750a6da50cbc652d231c9629d13a3e86456d219c56L4-R7) [[2]](diffhunk://#diff-f911d4d4e27a3c60b181c0750a6da50cbc652d231c9629d13a3e86456d219c56L17-R48)
* Added an asynchronous file appender (`ASYNC_FILE`) for improved logging performance, and updated root logger references to use it in all profiles.
* Adjusted logger verbosity for development and production profiles, setting more granular levels and removing unnecessary loggers.

**Containerization Enhancements:**

* Added a Docker volume (`app-logs`) for persistent application logs and mounted it in the application service, ensuring logs are retained outside the container lifecycle. [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R25-R26) [[2]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R71-R72)