### PR TITLE
Feature/mauricio/mokadex domain tests

### DIFF
--- a/src/main/java/br/edu/ufpel/rokamoka/controller/MokadexController.java
+++ b/src/main/java/br/edu/ufpel/rokamoka/controller/MokadexController.java
@@ -48,7 +48,7 @@ public class MokadexController extends RokaMokaController {
             @PathVariable(value = "qrcode") String qrCode)
             throws RokaMokaContentNotFoundException, RokaMokaContentDuplicatedException {
         Mokadex mokadex = this.mokadexService.collectStar(qrCode);
-        return success(this.mokadexService.getMokadexOutputDTOByMokadex(mokadex));
+        return this.success(this.mokadexService.getMokadexOutputDTOByMokadex(mokadex));
     }
 
     @Operation(
@@ -60,7 +60,7 @@ public class MokadexController extends RokaMokaController {
     @GetMapping("/missing/{exhibitionId}")
     public ResponseEntity<ApiResponseWrapper<Set<ArtworkOutputDTO>>> findMissingStarsByExhibition(
             @PathVariable Long exhibitionId) throws RokaMokaContentNotFoundException {
-        return success(this.mokadexService.getMissingStarsByExhibition(exhibitionId)
+        return this.success(this.mokadexService.getMissingStarsByExhibition(exhibitionId)
                 .stream()
                 .map(ArtworkOutputDTO::new)
                 .collect(Collectors.toUnmodifiableSet()));

--- a/src/main/java/br/edu/ufpel/rokamoka/service/mokadex/IMokadexService.java
+++ b/src/main/java/br/edu/ufpel/rokamoka/service/mokadex/IMokadexService.java
@@ -9,6 +9,7 @@ import br.edu.ufpel.rokamoka.exceptions.RokaMokaContentDuplicatedException;
 import br.edu.ufpel.rokamoka.exceptions.RokaMokaContentNotFoundException;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import org.springframework.validation.annotation.Validated;
 
 import java.util.Set;
 
@@ -18,13 +19,14 @@ import java.util.Set;
  * @author MauricioMucci
  * @see MokadexService
  */
+@Validated
 public interface IMokadexService {
 
     Mokadex findById(@NotNull Long mokadexId) throws RokaMokaContentNotFoundException;
 
-    Mokadex getOrCreateMokadexByUser(User usuario);
+    Mokadex getOrCreateMokadexByUser(@NotNull User usuario);
 
-    MokadexOutputDTO getMokadexOutputDTOByMokadex(Mokadex mokadex);
+    MokadexOutputDTO getMokadexOutputDTOByMokadex(@NotNull Mokadex mokadex);
 
     Mokadex collectStar(@NotBlank String qrCode)
             throws RokaMokaContentNotFoundException, RokaMokaContentDuplicatedException;

--- a/src/main/java/br/edu/ufpel/rokamoka/service/mokadex/MokadexService.java
+++ b/src/main/java/br/edu/ufpel/rokamoka/service/mokadex/MokadexService.java
@@ -16,7 +16,7 @@ import br.edu.ufpel.rokamoka.repository.MokadexRepository;
 import br.edu.ufpel.rokamoka.security.UserAuthenticated;
 import br.edu.ufpel.rokamoka.service.artwork.IArtworkService;
 import br.edu.ufpel.rokamoka.service.emblem.IEmblemService;
-import br.edu.ufpel.rokamoka.service.exhibition.ExhibitionService;
+import br.edu.ufpel.rokamoka.service.exhibition.IExhibitionService;
 import br.edu.ufpel.rokamoka.utils.mokadex.MokadexCollectionsBuilder;
 import br.edu.ufpel.rokamoka.utils.mokadex.MokadexEmblemsBuilder;
 import jakarta.validation.constraints.NotBlank;
@@ -49,7 +49,7 @@ public class MokadexService implements IMokadexService {
 
     private final IEmblemService emblemService;
     private final IArtworkService artworkService;
-    private final ExhibitionService exhibitionService;
+    private final IExhibitionService exhibitionService;
     private final CollectEmblemProducer collectEmblemProducer;
 
     @Override
@@ -70,11 +70,8 @@ public class MokadexService implements IMokadexService {
      */
     @Override
     @Transactional(propagation = Propagation.REQUIRED)
-    public Mokadex getOrCreateMokadexByUser(User user) {
-        if (user == null) {
-            throw new ServiceException("O usuário não pode ser nulo ao tentar criar ou recuperar o Mokadex");
-        }
-        return getMokadexByUser(user).orElseGet(() -> createMokadexByUser(user));
+    public Mokadex getOrCreateMokadexByUser(@NotNull User user) {
+        return this.getMokadexByUser(user).orElseGet(() -> this.createMokadexByUser(user));
     }
 
     /**
@@ -126,7 +123,7 @@ public class MokadexService implements IMokadexService {
      * @see MokadexEmblemsBuilder
      */
     @Override
-    public MokadexOutputDTO getMokadexOutputDTOByMokadex(Mokadex mokadex) {
+    public MokadexOutputDTO getMokadexOutputDTOByMokadex(@NotNull Mokadex mokadex) {
         log.info("Construindo {} para o {} informado", MokadexOutputDTO.class.getSimpleName(), mokadex);
 
         Set<CollectionDTO> collectionDTOSet = new MokadexCollectionsBuilder(mokadex).buildCollectionSet();
@@ -199,7 +196,7 @@ public class MokadexService implements IMokadexService {
     @Transactional(propagation = Propagation.REQUIRED)
     public Mokadex collectEmblem(Long mokadexId, Emblem emblem)
             throws RokaMokaContentNotFoundException, RokaMokaContentDuplicatedException {
-        Mokadex mokadex = findById(mokadexId);
+        Mokadex mokadex = this.findById(mokadexId);
 
         if (mokadex.containsEmblem(emblem)) {
             throw new RokaMokaContentDuplicatedException("Emblema já foi coletado");

--- a/src/test/java/br/edu/ufpel/rokamoka/controller/ControllerResponseValidator.java
+++ b/src/test/java/br/edu/ufpel/rokamoka/controller/ControllerResponseValidator.java
@@ -5,7 +5,8 @@ import org.junit.jupiter.api.Assertions;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
-import java.util.Collection;
+import java.util.List;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -47,27 +48,52 @@ public interface ControllerResponseValidator {
         assertNull(actual, "Output atual deve ser null");
     }
 
-    default <T> void assertCollectionResponse(ResponseEntity<ApiResponseWrapper<Collection<T>>> response) {
+    default <T> void assertListResponse(ResponseEntity<ApiResponseWrapper<List<T>>> response) {
         assertNotNull(response, "Response não deve ser null");
         assertEquals(HttpStatus.OK, response.getStatusCode(), "Status code deve ser OK");
 
-        ApiResponseWrapper<Collection<T>> body = response.getBody();
+        ApiResponseWrapper<List<T>> body = response.getBody();
         assertNotNull(body, "Body do response não deve ser null");
 
-        Collection<T> actual = body.getBody();
+        List<T> actual = body.getBody();
         assertNotNull(actual, "Output atual não deve ser null");
         assertFalse(actual.isEmpty(), "Output atual deve conter pelo menos um elemento");
         actual.forEach(Assertions::assertNotNull);
     }
 
-    default <T> void assertEmptyCollectionResponse(ResponseEntity<ApiResponseWrapper<Collection<T>>> response) {
+    default <T> void assertEmptyListResponse(ResponseEntity<ApiResponseWrapper<List<T>>> response) {
         assertNotNull(response, "Response não deve ser null");
         assertEquals(HttpStatus.OK, response.getStatusCode(), "Status code deve ser OK");
 
-        ApiResponseWrapper<Collection<T>> body = response.getBody();
+        ApiResponseWrapper<List<T>> body = response.getBody();
         assertNotNull(body, "Body do response não deve ser null");
 
-        Collection<T> actual = body.getBody();
+        List<T> actual = body.getBody();
+        assertNotNull(actual, "Output atual não deve ser null");
+        assertTrue(actual.isEmpty(), "Output atual deve estar vazio");
+    }
+
+    default <T> void assertSetResponse(ResponseEntity<ApiResponseWrapper<Set<T>>> response) {
+        assertNotNull(response, "Response não deve ser null");
+        assertEquals(HttpStatus.OK, response.getStatusCode(), "Status code deve ser OK");
+
+        ApiResponseWrapper<Set<T>> body = response.getBody();
+        assertNotNull(body, "Body do response não deve ser null");
+
+        Set<T> actual = body.getBody();
+        assertNotNull(actual, "Output atual não deve ser null");
+        assertFalse(actual.isEmpty(), "Output atual deve conter pelo menos um elemento");
+        actual.forEach(Assertions::assertNotNull);
+    }
+
+    default <T> void assertEmptySetResponse(ResponseEntity<ApiResponseWrapper<Set<T>>> response) {
+        assertNotNull(response, "Response não deve ser null");
+        assertEquals(HttpStatus.OK, response.getStatusCode(), "Status code deve ser OK");
+
+        ApiResponseWrapper<Set<T>> body = response.getBody();
+        assertNotNull(body, "Body do response não deve ser null");
+
+        Set<T> actual = body.getBody();
         assertNotNull(actual, "Output atual não deve ser null");
         assertTrue(actual.isEmpty(), "Output atual deve estar vazio");
     }

--- a/src/test/java/br/edu/ufpel/rokamoka/controller/MokadexControllerTest.java
+++ b/src/test/java/br/edu/ufpel/rokamoka/controller/MokadexControllerTest.java
@@ -1,0 +1,145 @@
+package br.edu.ufpel.rokamoka.controller;
+
+import br.edu.ufpel.rokamoka.context.ApiResponseWrapper;
+import br.edu.ufpel.rokamoka.core.Artwork;
+import br.edu.ufpel.rokamoka.core.Mokadex;
+import br.edu.ufpel.rokamoka.dto.artwork.output.ArtworkOutputDTO;
+import br.edu.ufpel.rokamoka.dto.mokadex.output.MokadexOutputDTO;
+import br.edu.ufpel.rokamoka.exceptions.RokaMokaContentDuplicatedException;
+import br.edu.ufpel.rokamoka.exceptions.RokaMokaContentNotFoundException;
+import br.edu.ufpel.rokamoka.service.mokadex.MokadexService;
+import org.instancio.Instancio;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+
+import java.util.Collections;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for the {@link MokadexController} class, which is responsible for handling mokadex-related endpoints.
+ *
+ * @author MauricioMucci
+ * @see MokadexService
+ */
+@ExtendWith(MockitoExtension.class)
+class MokadexControllerTest implements ControllerResponseValidator {
+
+    @InjectMocks private MokadexController mokadexController;
+
+    @Mock private MokadexService mokadexService;
+
+    //region collectStar
+    @Test
+    void collectStar_shouldReturnMokadexOutput_whenSuccessful()
+    throws RokaMokaContentDuplicatedException, RokaMokaContentNotFoundException {
+        // Arrange
+        MokadexOutputDTO expectedOutput = Instancio.create(MokadexOutputDTO.class);
+
+        when(this.mokadexService.collectStar(anyString())).thenReturn(mock(Mokadex.class));
+        when(this.mokadexService.getMokadexOutputDTOByMokadex(any(Mokadex.class)))
+                .thenReturn(expectedOutput);
+
+        // Act
+        ResponseEntity<ApiResponseWrapper<MokadexOutputDTO>> response = this.mokadexController.collectStar("qrCode");
+
+        // Assert
+        this.assertExpectedResponse(response, expectedOutput);
+
+        verify(this.mokadexService, times(1)).collectStar(anyString());
+        verify(this.mokadexService, times(1))
+                .getMokadexOutputDTOByMokadex(any(Mokadex.class));
+    }
+
+    @Test
+    void collectStar_shouldThrowRokaMokaContentNotFoundException_whenArtworkDoesNotExistByQrCode()
+    throws RokaMokaContentDuplicatedException, RokaMokaContentNotFoundException {
+        // Arrange
+        when(this.mokadexService.collectStar(anyString())).thenThrow(RokaMokaContentNotFoundException.class);
+
+        // Act & Assert
+        assertThrows(RokaMokaContentNotFoundException.class,
+                () -> this.mokadexController.collectStar("qrCode"));
+
+        verify(this.mokadexService, times(1)).collectStar(anyString());
+        verifyNoMoreInteractions(this.mokadexService);
+    }
+
+    @Test
+    void collectStar_shouldThrowRokaMokaContentDuplicatedException_whenArtworkAlreadyCollected()
+    throws RokaMokaContentDuplicatedException, RokaMokaContentNotFoundException {
+        // Arrange
+        when(this.mokadexService.collectStar(anyString())).thenThrow(RokaMokaContentDuplicatedException.class);
+
+        // Act & Assert
+        assertThrows(RokaMokaContentDuplicatedException.class,
+                () -> this.mokadexController.collectStar("qrCode"));
+
+        verify(this.mokadexService, times(1)).collectStar(anyString());
+        verifyNoMoreInteractions(this.mokadexService);
+    }
+    //endregion
+
+    //region findMissingStarsByExhibition
+    @Test
+    void findMissingStarsByExhibition_shouldReturnSetOfArtwork_whenExistMissingStarsToBeCollected()
+    throws RokaMokaContentNotFoundException {
+        // Arrange
+        Set<Artwork> artworks = Instancio.ofSet(Artwork.class).create();
+
+        when(this.mokadexService.getMissingStarsByExhibition(anyLong())).thenReturn(artworks);
+
+        // Act
+        ResponseEntity<ApiResponseWrapper<Set<ArtworkOutputDTO>>> response =
+                this.mokadexController.findMissingStarsByExhibition(1L);
+
+        // Assert
+        this.assertSetResponse(response);
+
+        verify(this.mokadexService, times(1)).getMissingStarsByExhibition(anyLong());
+    }
+
+    @Test
+    void findMissingStarsByExhibition_shouldReturnEmptySet_whenAllStarsWereCollected()
+    throws RokaMokaContentNotFoundException {
+        // Arrange
+        when(this.mokadexService.getMissingStarsByExhibition(anyLong())).thenReturn(Collections.emptySet());
+
+        // Act
+        ResponseEntity<ApiResponseWrapper<Set<ArtworkOutputDTO>>> response =
+                this.mokadexController.findMissingStarsByExhibition(1L);
+
+        // Assert
+        this.assertEmptySetResponse(response);
+
+        verify(this.mokadexService, times(1)).getMissingStarsByExhibition(anyLong());
+    }
+
+    @Test
+    void findMissingStarsByExhibition_shouldThrowRokaMokaContentNotFoundException_whenExhibitionDoesNotExistById()
+    throws RokaMokaContentNotFoundException {
+        // Arrange
+        when(this.mokadexService.getMissingStarsByExhibition(anyLong())).thenThrow(RokaMokaContentNotFoundException.class);
+
+        // Act & Assert
+        assertThrows(RokaMokaContentNotFoundException.class,
+                () -> this.mokadexController.findMissingStarsByExhibition(1L));
+
+        verify(this.mokadexService, times(1)).getMissingStarsByExhibition(anyLong());
+        verifyNoMoreInteractions(this.mokadexService);
+    }
+    //endregion
+}

--- a/src/test/java/br/edu/ufpel/rokamoka/service/MockRepository.java
+++ b/src/test/java/br/edu/ufpel/rokamoka/service/MockRepository.java
@@ -1,0 +1,10 @@
+package br.edu.ufpel.rokamoka.service;
+
+/**
+ *
+ * @author MauricioMucci
+ */
+public interface MockRepository<T> {
+
+    T mockRepositorySave(T entity);
+}

--- a/src/test/java/br/edu/ufpel/rokamoka/service/MockRepository.java
+++ b/src/test/java/br/edu/ufpel/rokamoka/service/MockRepository.java
@@ -1,10 +1,37 @@
 package br.edu.ufpel.rokamoka.service;
 
+import java.lang.reflect.Method;
+
 /**
+ * Interface for mocking repositories methods.
  *
+ * @param <T> Type of entity.
  * @author MauricioMucci
  */
 public interface MockRepository<T> {
 
-    T mockRepositorySave(T entity);
+    Long DEFAULT_ID = 1L;
+
+    default T mockRepositorySave(T entity) {
+        if (entity == null) {
+            throw new IllegalArgumentException("Entity cannot be null");
+        }
+
+        this.tryToSetId(entity);
+
+        return entity;
+    }
+
+    private void tryToSetId(T entity) {
+        try {
+            Method getId = entity.getClass().getMethod("getId");
+            Object id = getId.invoke(entity);
+            if (id == null) {
+                Method setId = entity.getClass().getMethod("setId", Long.class);
+                setId.invoke(entity, DEFAULT_ID);
+            }
+        } catch (Exception e) {
+            throw new IllegalStateException("Falha ao atribuir ID ao objeto: " + entity.getClass().getName(), e);
+        }
+    }
 }

--- a/src/test/java/br/edu/ufpel/rokamoka/service/MockUserSession.java
+++ b/src/test/java/br/edu/ufpel/rokamoka/service/MockUserSession.java
@@ -1,0 +1,24 @@
+package br.edu.ufpel.rokamoka.service;
+
+import br.edu.ufpel.rokamoka.context.ServiceContext;
+import br.edu.ufpel.rokamoka.security.UserAuthenticated;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ *
+ * @author MauricioMucci
+ */
+public interface MockUserSession {
+
+    String LOGGED_USER_NAME = "loggedUserName";
+
+    default ServiceContext mockServiceContext() {
+        ServiceContext mockContext = mock(ServiceContext.class);
+        UserAuthenticated mockUserAuthenticated = mock(UserAuthenticated.class);
+        when(mockContext.getUser()).thenReturn(mockUserAuthenticated);
+        when(mockUserAuthenticated.getUsername()).thenReturn(LOGGED_USER_NAME);
+        return mockContext;
+    }
+}

--- a/src/test/java/br/edu/ufpel/rokamoka/service/mokadex/MokadexServiceTest.java
+++ b/src/test/java/br/edu/ufpel/rokamoka/service/mokadex/MokadexServiceTest.java
@@ -76,14 +76,6 @@ class MokadexServiceTest implements MockUserSession, MockRepository<Mokadex> {
     @Mock private ExhibitionService exhibitionService;
     @Mock private CollectEmblemProducer collectEmblemProducer;
 
-    @Override
-    public Mokadex mockRepositorySave(Mokadex mokadex) {
-        if (mokadex.getId() == null) {
-            mokadex.setId(1L);
-        }
-        return mokadex;
-    }
-
     //region findById
     @ParameterizedTest
     @ValueSource(longs = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10})
@@ -398,7 +390,7 @@ class MokadexServiceTest implements MockUserSession, MockRepository<Mokadex> {
         when(this.mokadexRepository.save(mokadex)).thenAnswer(
                 inv -> this.mockRepositorySave(inv.getArgument(0)));
         when(this.emblemService.existsEmblemByExhibitionId(anyLong())).thenReturn(true);
-        when(mokadex.getId()).thenReturn(1L);
+        when(mokadex.getId()).thenReturn(DEFAULT_ID);
         when(this.mokadexRepository.hasCollectedAllArtworksInExhibition(anyLong(), anyLong()))
                 .thenReturn(true);
 
@@ -415,8 +407,6 @@ class MokadexServiceTest implements MockUserSession, MockRepository<Mokadex> {
         verify(mokadex, times(1)).addArtwork(any(Artwork.class));
         verify(this.emblemService, times(1)).existsEmblemByExhibitionId(anyLong());
         verify(this.mokadexRepository, times(1)).save(any(Mokadex.class));
-        verify(mokadex, times(1)).setId(1L);
-        verify(mokadex, times(1)).getId();
         verify(this.mokadexRepository, times(1)).hasCollectedAllArtworksInExhibition(
                 anyLong(), anyLong());
         verify(this.collectEmblemProducer, times(1)).publishCollectEmblem(

--- a/src/test/java/br/edu/ufpel/rokamoka/service/mokadex/MokadexServiceTest.java
+++ b/src/test/java/br/edu/ufpel/rokamoka/service/mokadex/MokadexServiceTest.java
@@ -1,31 +1,52 @@
 package br.edu.ufpel.rokamoka.service.mokadex;
 
 import br.edu.ufpel.rokamoka.component.CollectEmblemProducer;
+import br.edu.ufpel.rokamoka.context.ServiceContext;
+import br.edu.ufpel.rokamoka.core.Artwork;
+import br.edu.ufpel.rokamoka.core.Emblem;
+import br.edu.ufpel.rokamoka.core.Exhibition;
 import br.edu.ufpel.rokamoka.core.Mokadex;
 import br.edu.ufpel.rokamoka.core.User;
+import br.edu.ufpel.rokamoka.dto.emblem.output.EmblemOutputDTO;
+import br.edu.ufpel.rokamoka.dto.mokadex.output.CollectionDTO;
 import br.edu.ufpel.rokamoka.dto.mokadex.output.MokadexOutputDTO;
+import br.edu.ufpel.rokamoka.exceptions.RokaMokaContentDuplicatedException;
 import br.edu.ufpel.rokamoka.exceptions.RokaMokaContentNotFoundException;
 import br.edu.ufpel.rokamoka.repository.MokadexRepository;
+import br.edu.ufpel.rokamoka.service.MockUserSession;
 import br.edu.ufpel.rokamoka.service.artwork.ArtworkService;
 import br.edu.ufpel.rokamoka.service.emblem.EmblemService;
 import br.edu.ufpel.rokamoka.service.exhibition.ExhibitionService;
+import org.hibernate.service.spi.ServiceException;
 import org.instancio.Instancio;
-import org.instancio.Select;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Stream;
 
+import static org.instancio.Select.field;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -43,7 +64,7 @@ import static org.mockito.Mockito.when;
  * @see CollectEmblemProducer
  */
 @ExtendWith(MockitoExtension.class)
-class MokadexServiceTest {
+class MokadexServiceTest implements MockUserSession {
 
     @InjectMocks private MokadexService mokadexService;
 
@@ -60,7 +81,7 @@ class MokadexServiceTest {
     void findById_shouldReturnMokadex_whenMokadexExistsById(Long id) throws RokaMokaContentNotFoundException {
         // Arrange
         Mokadex expected = Instancio.of(Mokadex.class)
-                .set(Select.field(Mokadex::getId), id)
+                .set(field(Mokadex::getId), id)
                 .create();
 
         when(this.mokadexRepository.findById(id)).thenReturn(Optional.of(expected));
@@ -92,7 +113,7 @@ class MokadexServiceTest {
         // Arrange
         User user = Instancio.create(User.class);
         Mokadex expected = Instancio.of(Mokadex.class)
-                .set(Select.field(Mokadex::getUsuario), user)
+                .set(field(Mokadex::getUsuario), user)
                 .create();
 
         when(this.mokadexRepository.findMokadexByUsername(user.getNome())).thenReturn(Optional.of(expected));
@@ -105,7 +126,8 @@ class MokadexServiceTest {
 
         verify(this.mokadexRepository, times(1)).findMokadexByUsername(user.getNome());
         verifyNoMoreInteractions(this.mokadexRepository);
-        verifyNoInteractions(this.emblemService, this.artworkService, this.exhibitionService, this.collectEmblemProducer);
+        verifyNoInteractions(this.emblemService, this.artworkService, this.exhibitionService,
+                this.collectEmblemProducer);
     }
 
     @Test
@@ -126,7 +148,8 @@ class MokadexServiceTest {
 
         verify(this.mokadexRepository, times(1)).save(any(Mokadex.class));
         verifyNoMoreInteractions(this.mokadexRepository);
-        verifyNoInteractions(this.emblemService, this.artworkService, this.exhibitionService, this.collectEmblemProducer);
+        verifyNoInteractions(this.emblemService, this.artworkService, this.exhibitionService,
+                this.collectEmblemProducer);
     }
 
     private Mokadex mockMokadexRepositorySave(Mokadex mokadex) {
@@ -136,37 +159,353 @@ class MokadexServiceTest {
     //endregion
 
     //region getMokadexOutputDTOByMokadex
-    @Test
-    void getMokadexOutputDTOByMokadex_shouldBuildMokadexOutputDTO_whenCalled() {
-        // Arrange
-        Mokadex mokadex = Instancio.create(Mokadex.class);
+    static Stream<Arguments> buildGetMokadexOutputDTOByMokadexInput() {
+        Mokadex sampleMokadex = Instancio.create(Mokadex.class);
+        Mokadex emptyArtwork = Instancio.of(Mokadex.class)
+                .set(field(Mokadex::getArtworks), Collections.emptySet())
+                .create();
+        Mokadex emptyEmblem = Instancio.of(Mokadex.class)
+                .set(field(Mokadex::getEmblems), Collections.emptySet())
+                .create();
+        Mokadex emptyMokadex = Instancio.of(Mokadex.class)
+                .set(field(Mokadex::getArtworks), Collections.emptySet())
+                .set(field(Mokadex::getEmblems), Collections.emptySet())
+                .create();
+        return Stream.of(
+                Arguments.of(sampleMokadex),
+                Arguments.of(emptyArtwork),
+                Arguments.of(emptyEmblem),
+                Arguments.of(emptyMokadex)
+        );
+    }
 
-        // Act
+    @ParameterizedTest
+    @MethodSource("buildGetMokadexOutputDTOByMokadexInput")
+    void getMokadexOutputDTOByMokadex_shouldBuildMokadexOutputDTO_whenCalled(Mokadex mokadex) {
         MokadexOutputDTO actual = this.mokadexService.getMokadexOutputDTOByMokadex(mokadex);
-
-        // Assert
         assertNotNull(actual);
-        assertNotNull(actual.collectionSet());
-        assertNotNull(actual.emblemSet());
+
+        Set<CollectionDTO> outputCollection = actual.collectionSet();
+        assertNotNull(outputCollection);
+        if (mokadex.getArtworks().isEmpty()) {
+            assertTrue(outputCollection.isEmpty());
+        } else {
+            assertFalse(outputCollection.isEmpty());
+        }
+
+        Set<EmblemOutputDTO> outputEmblems = actual.emblemSet();
+        assertNotNull(outputEmblems);
+        if (mokadex.getEmblems().isEmpty()) {
+            assertTrue(outputEmblems.isEmpty());
+        } else {
+            assertFalse(outputEmblems.isEmpty());
+        }
     }
     //endregion
 
-    // TODO bellow
     //region collectStar
     @Test
-    void collectStar() {
+    void collectStar_shouldThrowServiceException_whenMokadexDoesNotExistForLoggedUser() {
+        // Arrange
+        ServiceContext mockContext = this.mockServiceContext();
+
+        when(this.mokadexRepository.findMokadexByUsername(anyString())).thenReturn(Optional.empty());
+
+        // Act & Assert
+        try (MockedStatic<ServiceContext> mockedServiceContext = mockStatic(ServiceContext.class)) {
+            mockedServiceContext.when(ServiceContext::getContext).thenReturn(mockContext);
+
+            assertThrows(ServiceException.class,
+                    () -> this.mokadexService.collectStar("QRCODE"));
+        }
+
+        verify(this.mokadexRepository, times(1)).findMokadexByUsername(anyString());
+        verifyNoMoreInteractions(this.mokadexRepository);
+        verifyNoInteractions(this.exhibitionService, this.artworkService, this.emblemService,
+                this.collectEmblemProducer);
+    }
+
+    @Test
+    void collectStar_shouldThrowRokaMokaContentNotFoundException_whenArtworkDoesNotExistForQRCode() {
+        // Arrange
+        ServiceContext mockContext = this.mockServiceContext();
+
+        when(this.mokadexRepository.findMokadexByUsername(anyString()))
+                .thenReturn(Optional.of(new Mokadex()));
+        when(this.artworkService.findByQrCode(anyString())).thenReturn(Optional.empty());
+
+        // Act & Assert
+        try (MockedStatic<ServiceContext> mockedServiceContext = mockStatic(ServiceContext.class)) {
+            mockedServiceContext.when(ServiceContext::getContext).thenReturn(mockContext);
+
+            assertThrows(RokaMokaContentNotFoundException.class,
+                    () -> this.mokadexService.collectStar("QRCODE"));
+        }
+
+        verify(this.mokadexRepository, times(1)).findMokadexByUsername(anyString());
+        verify(this.artworkService, times(1)).findByQrCode(anyString());
+        verifyNoMoreInteractions(this.mokadexRepository, this.artworkService);
+        verifyNoInteractions(this.exhibitionService, this.emblemService, this.collectEmblemProducer);
+    }
+
+    @Test
+    void collectStar_shouldThrowRokaMokaContentDuplicatedException_whenMokadexAlreadyContainsArtwork() {
+        // Arrange
+        ServiceContext mockContext = this.mockServiceContext();
+        Mokadex mokadex = mock(Mokadex.class);
+
+        when(this.mokadexRepository.findMokadexByUsername(anyString())).thenReturn(Optional.of(mokadex));
+        when(this.artworkService.findByQrCode(anyString())).thenReturn(Optional.of(new Artwork()));
+        when(mokadex.containsArtwork(any(Artwork.class))).thenReturn(true);
+
+        // Act & Assert
+        try (MockedStatic<ServiceContext> mockedServiceContext = mockStatic(ServiceContext.class)) {
+            mockedServiceContext.when(ServiceContext::getContext).thenReturn(mockContext);
+
+            assertThrows(RokaMokaContentDuplicatedException.class,
+                    () -> this.mokadexService.collectStar("QRCODE"));
+        }
+
+        verify(this.mokadexRepository, times(1)).findMokadexByUsername(anyString());
+        verify(this.artworkService, times(1)).findByQrCode(anyString());
+        verify(mokadex, times(1)).containsArtwork(any(Artwork.class));
+        verifyNoMoreInteractions(this.mokadexRepository, this.artworkService, mokadex);
+        verifyNoInteractions(this.exhibitionService, this.emblemService, this.collectEmblemProducer);
+    }
+
+    @Test
+    void collectStar_shouldThrowServiceException_whenMokadexFailsToCollectStar() {
+        // Arrange
+        ServiceContext mockContext = this.mockServiceContext();
+        Mokadex mokadex = mock(Mokadex.class);
+
+        when(this.mokadexRepository.findMokadexByUsername(anyString())).thenReturn(Optional.of(mokadex));
+        when(this.artworkService.findByQrCode(anyString())).thenReturn(Optional.of(new Artwork()));
+        when(mokadex.containsArtwork(any(Artwork.class))).thenReturn(false);
+        when(mokadex.addArtwork(any(Artwork.class))).thenReturn(false);
+
+        // Act & Assert
+        try (MockedStatic<ServiceContext> mockedServiceContext = mockStatic(ServiceContext.class)) {
+            mockedServiceContext.when(ServiceContext::getContext).thenReturn(mockContext);
+
+            assertThrows(ServiceException.class,
+                    () -> this.mokadexService.collectStar("QRCODE"));
+        }
+
+        verify(this.mokadexRepository, times(1)).findMokadexByUsername(anyString());
+        verify(this.artworkService, times(1)).findByQrCode(anyString());
+        verify(mokadex, times(1)).containsArtwork(any(Artwork.class));
+        verify(mokadex, times(1)).addArtwork(any(Artwork.class));
+        verifyNoMoreInteractions(this.mokadexRepository, this.artworkService, mokadex);
+        verifyNoInteractions(this.exhibitionService, this.emblemService, this.collectEmblemProducer);
+    }
+
+    @Test
+    void collectStar_shouldCollectStarAndUpdateMokadexAndPublishMessage_whenMokadexDoesNotContainArtwork()
+    throws RokaMokaContentDuplicatedException, RokaMokaContentNotFoundException {
+        // Arrange
+        ServiceContext mockContext = this.mockServiceContext();
+        Mokadex mokadex = mock(Mokadex.class);
+        Artwork artwork = Instancio.create(Artwork.class);
+
+        when(this.mokadexRepository.findMokadexByUsername(anyString())).thenReturn(Optional.of(mokadex));
+        when(this.artworkService.findByQrCode(anyString())).thenReturn(Optional.of(artwork));
+        when(mokadex.containsArtwork(artwork)).thenReturn(false);
+        when(mokadex.addArtwork(artwork)).thenReturn(true);
+        when(this.mokadexRepository.save(mokadex)).thenAnswer(
+                inv -> this.mockMokadexRepositorySave(inv.getArgument(0)));
+
+        // Act & Assert
+        try (MockedStatic<ServiceContext> mockedServiceContext = mockStatic(ServiceContext.class)) {
+            mockedServiceContext.when(ServiceContext::getContext).thenReturn(mockContext);
+
+            this.mokadexService.collectStar("QRCODE");
+        }
+
+        // TODO finish collect star mocking
+
+        verify(this.mokadexRepository, times(1)).findMokadexByUsername(anyString());
+        verify(this.artworkService, times(1)).findByQrCode(anyString());
+        verify(mokadex, times(1)).containsArtwork(any(Artwork.class));
+        verify(mokadex, times(1)).addArtwork(any(Artwork.class));
+        verify(this.mokadexRepository, times(1)).save(any(Mokadex.class));
+        verify(this.collectEmblemProducer, times(1)).publishCollectEmblem(
+                any(Mokadex.class), any(Exhibition.class));
+        verifyNoMoreInteractions(this.mokadexRepository, this.artworkService, mokadex);
+        verifyNoInteractions(this.exhibitionService, this.emblemService);
     }
     //endregion
 
     //region collectEmblem
     @Test
-    void collectEmblem() {
+    void collectEmblem_shouldCollectEmblemAndUpdateMokadex_whenMokadexDoesNotContainEmblem()
+    throws RokaMokaContentDuplicatedException, RokaMokaContentNotFoundException {
+        // Arrange
+        Mokadex mokadex = mock(Mokadex.class);
+
+        when(this.mokadexRepository.findById(anyLong())).thenReturn(Optional.of(mokadex));
+        when(mokadex.containsEmblem(any(Emblem.class))).thenReturn(false);
+        when(mokadex.addEmblem(any(Emblem.class))).thenReturn(true);
+
+        // Act & Assert
+        this.mokadexService.collectEmblem(1L, new Emblem());
+
+        verify(this.mokadexRepository, times(1)).findById(anyLong());
+        verify(mokadex, times(1)).containsEmblem(any(Emblem.class));
+        verify(mokadex, times(1)).addEmblem(any(Emblem.class));
+        verify(this.mokadexRepository, times(1)).save(mokadex);
+        verifyNoMoreInteractions(this.mokadexRepository, mokadex);
+        verifyNoInteractions(this.artworkService, this.emblemService, this.exhibitionService,
+                this.collectEmblemProducer);
+    }
+
+    @Test
+    void collectEmblem_shouldThrowRokaMokaContentDuplicatedException_whenMokadexAlreadyContainsEmblem() {
+        // Arrange
+        Mokadex mokadex = mock(Mokadex.class);
+
+        when(this.mokadexRepository.findById(anyLong())).thenReturn(Optional.of(mokadex));
+        when(mokadex.containsEmblem(any(Emblem.class))).thenReturn(true);
+
+        // Act & Assert
+        assertThrows(RokaMokaContentDuplicatedException.class,
+                () -> this.mokadexService.collectEmblem(1L, new Emblem()));
+
+        verify(this.mokadexRepository, times(1)).findById(anyLong());
+        verify(mokadex, times(1)).containsEmblem(any(Emblem.class));
+        verifyNoMoreInteractions(this.mokadexRepository, mokadex);
+        verifyNoInteractions(this.artworkService, this.emblemService, this.exhibitionService,
+                this.collectEmblemProducer);
+    }
+
+    @Test
+    void collectEmblem_shouldThrowServiceException_whenMokadexFailsToCollectEmblem() {
+        // Arrange
+        Mokadex mokadex = mock(Mokadex.class);
+
+        when(this.mokadexRepository.findById(anyLong())).thenReturn(Optional.of(mokadex));
+        when(mokadex.containsEmblem(any(Emblem.class))).thenReturn(false);
+        when(mokadex.addEmblem(any(Emblem.class))).thenReturn(false);
+
+        // Act & Assert
+        assertThrows(ServiceException.class,
+                () -> this.mokadexService.collectEmblem(1L, new Emblem()));
+
+        verify(this.mokadexRepository, times(1)).findById(anyLong());
+        verify(mokadex, times(1)).containsEmblem(any(Emblem.class));
+        verify(mokadex, times(1)).addEmblem(any(Emblem.class));
+        verifyNoMoreInteractions(this.mokadexRepository, mokadex);
+        verifyNoInteractions(this.artworkService, this.emblemService, this.exhibitionService,
+                this.collectEmblemProducer);
+    }
+
+    @Test
+    void collectEmblem_shouldThrowRokaMokaContentNotFoundException_whenMokadexDoesNotExistById() {
+        // Arrange
+        when(this.mokadexRepository.findById(anyLong())).thenReturn(Optional.empty());
+
+        // Act & Assert
+        assertThrows(RokaMokaContentNotFoundException.class,
+                () -> this.mokadexService.collectEmblem(1L, new Emblem()));
+
+        verify(this.mokadexRepository, times(1)).findById(anyLong());
+        verifyNoMoreInteractions(this.mokadexRepository);
+        verifyNoInteractions(this.artworkService, this.emblemService, this.exhibitionService,
+                this.collectEmblemProducer);
     }
     //endregion
 
     //region getMissingStarsByExhibition
+    static Stream<Arguments> buildGetMissingStarsByExhibitionInput() {
+        Exhibition exhibition = Instancio.create(Exhibition.class);
+        Mokadex mokadex = Instancio.of(Mokadex.class)
+                .set(field(Mokadex::getEmblems), new HashSet<>(Set.of(exhibition)))
+                .create();
+        Set<Artwork> artworks = Instancio.ofSet(Artwork.class)
+                .set(field(Artwork::getExhibition), exhibition)
+                .create();
+        return Stream.of(
+                Arguments.of(exhibition, mokadex, artworks),
+                Arguments.of(exhibition, mokadex, Collections.emptySet())
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("buildGetMissingStarsByExhibitionInput")
+    void getMissingStarsByExhibition_shouldReturnSetOfArtwork_whenInputIsValid(Exhibition exhibition, Mokadex mokadex,
+            Set<Artwork> expected) throws RokaMokaContentNotFoundException {
+        // Arrange
+        ServiceContext mockContext = this.mockServiceContext();
+
+        when(this.mokadexRepository.findMokadexByUsername(anyString())).thenReturn(Optional.of(mokadex));
+        when(this.exhibitionService.findById(anyLong())).thenReturn(exhibition);
+        when(this.mokadexRepository.findAllMissingStars(mokadex.getId(), exhibition.getId())).thenReturn(expected);
+
+        // Act & Assert
+        try (MockedStatic<ServiceContext> mockedServiceContext = mockStatic(ServiceContext.class)) {
+            mockedServiceContext.when(ServiceContext::getContext).thenReturn(mockContext);
+
+            Set<Artwork> actual = this.mokadexService.getMissingStarsByExhibition(1L);
+
+            assertNotNull(actual);
+            if (expected.isEmpty()) {
+                assertTrue(actual.isEmpty());
+            } else {
+                assertFalse(actual.isEmpty());
+            }
+        }
+
+        verify(this.mokadexRepository, times(1)).findMokadexByUsername(anyString());
+        verify(this.exhibitionService, times(1)).findById(anyLong());
+        verify(this.mokadexRepository, times(1)).findAllMissingStars(
+                mokadex.getId(), exhibition.getId());
+        verifyNoMoreInteractions(this.mokadexRepository, this.exhibitionService);
+        verifyNoInteractions(this.artworkService, this.emblemService, this.collectEmblemProducer);
+    }
+
     @Test
-    void getMissingStarsByExhibition() {
+    void getMissingStarsByExhibition_shouldThrowServiceException_whenMokadexDoesNotExistForLoggedUser() {
+        // Arrange
+        ServiceContext mockContext = this.mockServiceContext();
+
+        when(this.mokadexRepository.findMokadexByUsername(anyString())).thenReturn(Optional.empty());
+
+        // Act & Assert
+        try (MockedStatic<ServiceContext> mockedServiceContext = mockStatic(ServiceContext.class)) {
+            mockedServiceContext.when(ServiceContext::getContext).thenReturn(mockContext);
+
+            assertThrows(ServiceException.class,
+                    () -> this.mokadexService.getMissingStarsByExhibition(1L));
+        }
+
+        verify(this.mokadexRepository, times(1)).findMokadexByUsername(anyString());
+        verifyNoMoreInteractions(this.mokadexRepository);
+        verifyNoInteractions(this.exhibitionService, this.artworkService, this.emblemService,
+                this.collectEmblemProducer);
+    }
+
+    @Test
+    void getMissingStarsByExhibition_shouldThrowRokaMokaContentNotFoundException_whenExhibitionDoesNotExistById()
+    throws RokaMokaContentNotFoundException {
+        // Arrange
+        Mokadex mokadex = Instancio.create(Mokadex.class);
+        ServiceContext mockContext = this.mockServiceContext();
+
+        when(this.mokadexRepository.findMokadexByUsername(anyString())).thenReturn(Optional.of(mokadex));
+        when(this.exhibitionService.findById(anyLong())).thenThrow(RokaMokaContentNotFoundException.class);
+
+        // Act & Assert
+        try (MockedStatic<ServiceContext> mockedServiceContext = mockStatic(ServiceContext.class)) {
+            mockedServiceContext.when(ServiceContext::getContext).thenReturn(mockContext);
+
+            assertThrows(RokaMokaContentNotFoundException.class,
+                    () -> this.mokadexService.getMissingStarsByExhibition(1L));
+        }
+
+        verify(this.mokadexRepository, times(1)).findMokadexByUsername(anyString());
+        verify(this.exhibitionService, times(1)).findById(anyLong());
+        verifyNoMoreInteractions(this.mokadexRepository, this.exhibitionService);
+        verifyNoInteractions(this.artworkService, this.emblemService, this.collectEmblemProducer);
     }
     //endregion
 }

--- a/src/test/java/br/edu/ufpel/rokamoka/service/mokadex/MokadexServiceTest.java
+++ b/src/test/java/br/edu/ufpel/rokamoka/service/mokadex/MokadexServiceTest.java
@@ -1,0 +1,172 @@
+package br.edu.ufpel.rokamoka.service.mokadex;
+
+import br.edu.ufpel.rokamoka.component.CollectEmblemProducer;
+import br.edu.ufpel.rokamoka.core.Mokadex;
+import br.edu.ufpel.rokamoka.core.User;
+import br.edu.ufpel.rokamoka.dto.mokadex.output.MokadexOutputDTO;
+import br.edu.ufpel.rokamoka.exceptions.RokaMokaContentNotFoundException;
+import br.edu.ufpel.rokamoka.repository.MokadexRepository;
+import br.edu.ufpel.rokamoka.service.artwork.ArtworkService;
+import br.edu.ufpel.rokamoka.service.emblem.EmblemService;
+import br.edu.ufpel.rokamoka.service.exhibition.ExhibitionService;
+import org.instancio.Instancio;
+import org.instancio.Select;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for the {@link MokadexService} class, which is responsible for handling mokadex-related API operations.
+ *
+ * @author MauricioMucci
+ * @see MokadexRepository
+ * @see EmblemService
+ * @see ArtworkService
+ * @see ExhibitionService
+ * @see CollectEmblemProducer
+ */
+@ExtendWith(MockitoExtension.class)
+class MokadexServiceTest {
+
+    @InjectMocks private MokadexService mokadexService;
+
+    @Mock private MokadexRepository mokadexRepository;
+
+    @Mock private EmblemService emblemService;
+    @Mock private ArtworkService artworkService;
+    @Mock private ExhibitionService exhibitionService;
+    @Mock private CollectEmblemProducer collectEmblemProducer;
+
+    //region findById
+    @ParameterizedTest
+    @ValueSource(longs = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10})
+    void findById_shouldReturnMokadex_whenMokadexExistsById(Long id) throws RokaMokaContentNotFoundException {
+        // Arrange
+        Mokadex expected = Instancio.of(Mokadex.class)
+                .set(Select.field(Mokadex::getId), id)
+                .create();
+
+        when(this.mokadexRepository.findById(id)).thenReturn(Optional.of(expected));
+
+        // Act
+        Mokadex actual = this.mokadexService.findById(id);
+
+        // Assert
+        assertEquals(expected, actual);
+
+        verify(this.mokadexRepository).findById(id);
+    }
+
+    @Test
+    void findById_shouldThrowRokaMokaContentNotFoundException_whenMokadexDoesNotExistById() {
+        // Arrange
+        when(this.mokadexRepository.findById(anyLong())).thenReturn(Optional.empty());
+
+        // Act & Assert
+        assertThrows(RokaMokaContentNotFoundException.class, () -> this.mokadexService.findById(1L));
+
+        verify(this.mokadexRepository).findById(anyLong());
+    }
+    //endregion
+
+    //region getOrCreateMokadexByUser
+    @Test
+    void getOrCreateMokadexByUser_shouldGetMokadex_whenMokadexExistsByUser() {
+        // Arrange
+        User user = Instancio.create(User.class);
+        Mokadex expected = Instancio.of(Mokadex.class)
+                .set(Select.field(Mokadex::getUsuario), user)
+                .create();
+
+        when(this.mokadexRepository.findMokadexByUsername(user.getNome())).thenReturn(Optional.of(expected));
+
+        // Act
+        Mokadex actual = this.mokadexService.getOrCreateMokadexByUser(user);
+
+        // Assert
+        assertEquals(expected, actual);
+
+        verify(this.mokadexRepository, times(1)).findMokadexByUsername(user.getNome());
+        verifyNoMoreInteractions(this.mokadexRepository);
+        verifyNoInteractions(this.emblemService, this.artworkService, this.exhibitionService, this.collectEmblemProducer);
+    }
+
+    @Test
+    void getOrCreateMokadexByUser_shouldCreateMokadex_whenMokadexDoesNotExistByUser() {
+        // Arrange
+        User user = Instancio.create(User.class);
+
+        when(this.mokadexRepository.findMokadexByUsername(user.getNome())).thenReturn(Optional.empty());
+        when(this.mokadexRepository.save(any(Mokadex.class))).thenAnswer(
+                inv -> this.mockMokadexRepositorySave(inv.getArgument(0)));
+
+        // Act
+        Mokadex actual = this.mokadexService.getOrCreateMokadexByUser(user);
+
+        // Assert
+        assertNotNull(actual);
+        assertEquals(user, actual.getUsuario());
+
+        verify(this.mokadexRepository, times(1)).save(any(Mokadex.class));
+        verifyNoMoreInteractions(this.mokadexRepository);
+        verifyNoInteractions(this.emblemService, this.artworkService, this.exhibitionService, this.collectEmblemProducer);
+    }
+
+    private Mokadex mockMokadexRepositorySave(Mokadex mokadex) {
+        mokadex.setId(1L);
+        return mokadex;
+    }
+    //endregion
+
+    //region getMokadexOutputDTOByMokadex
+    @Test
+    void getMokadexOutputDTOByMokadex_shouldBuildMokadexOutputDTO_whenCalled() {
+        // Arrange
+        Mokadex mokadex = Instancio.create(Mokadex.class);
+
+        // Act
+        MokadexOutputDTO actual = this.mokadexService.getMokadexOutputDTOByMokadex(mokadex);
+
+        // Assert
+        assertNotNull(actual);
+        assertNotNull(actual.collectionSet());
+        assertNotNull(actual.emblemSet());
+    }
+    //endregion
+
+    // TODO bellow
+    //region collectStar
+    @Test
+    void collectStar() {
+    }
+    //endregion
+
+    //region collectEmblem
+    @Test
+    void collectEmblem() {
+    }
+    //endregion
+
+    //region getMissingStarsByExhibition
+    @Test
+    void getMissingStarsByExhibition() {
+    }
+    //endregion
+}


### PR DESCRIPTION
This pull request introduces several improvements and refactorings to both the Mokadex feature and the test utilities. The most significant changes involve enhancing controller and service validation, improving test coverage and utility, and refactoring for better code consistency and maintainability.

**Controller and Service Improvements:**

* Added `@Validated` annotation to `IMokadexService` and improved null-safety by adding `@NotNull` and `@NotBlank` annotations to relevant method parameters. [[1]](diffhunk://#diff-b985f7a36460000129a5a513bb9c7b47335d1d98a095d361b6a877851819c94eR12) [[2]](diffhunk://#diff-b985f7a36460000129a5a513bb9c7b47335d1d98a095d361b6a877851819c94eR22-R29)
* Updated the Mokadex service and controller to consistently use `this.` for method calls and improved method signatures for clarity and validation. [[1]](diffhunk://#diff-398ab64dac0b454fde973f6b0988fddf6835ebfa6b777e9bb7e1b7d647e5ece2L73-R74) [[2]](diffhunk://#diff-398ab64dac0b454fde973f6b0988fddf6835ebfa6b777e9bb7e1b7d647e5ece2L129-R126) [[3]](diffhunk://#diff-398ab64dac0b454fde973f6b0988fddf6835ebfa6b777e9bb7e1b7d647e5ece2L202-R199) [[4]](diffhunk://#diff-1ca9a471252093051d809bd1f62951be66700f2d686c174b904397ed4ace1810L51-R51) [[5]](diffhunk://#diff-1ca9a471252093051d809bd1f62951be66700f2d686c174b904397ed4ace1810L63-R63)
* Changed dependency from `ExhibitionService` to its interface `IExhibitionService` for improved testability and abstraction. [[1]](diffhunk://#diff-398ab64dac0b454fde973f6b0988fddf6835ebfa6b777e9bb7e1b7d647e5ece2L19-R19) [[2]](diffhunk://#diff-398ab64dac0b454fde973f6b0988fddf6835ebfa6b777e9bb7e1b7d647e5ece2L52-R52)

**Testing Enhancements:**

* Added comprehensive unit tests for `MokadexController` covering both successful and exceptional scenarios for star collection and missing stars queries.
* Expanded `ControllerResponseValidator` to add new assertion methods for set responses and improved collection response assertions, supporting both lists and sets. [[1]](diffhunk://#diff-72c0af3d6dc5b9a9cc73cbd50c800250408e84b1aff6b55a457aaf730017882fL8-R9) [[2]](diffhunk://#diff-72c0af3d6dc5b9a9cc73cbd50c800250408e84b1aff6b55a457aaf730017882fL50-R96)
* Introduced `MockRepository` and `MockUserSession` interfaces to simplify mocking repositories and user sessions in tests. [[1]](diffhunk://#diff-101e9fa41b26527cd3ef7953c9c7012c231e542809951f667b6e6ed88c2813d2R1-R37) [[2]](diffhunk://#diff-4888cce3b227e5b3eb21eb535bf8f0c97da6ebe5c787912a9c74ae9f3235640fR1-R24)
* Refactored `UserServiceTest` to use the new `MockUserSession` utility, removing duplicated mocking logic and improving maintainability. [[1]](diffhunk://#diff-67b9304a1d7410bb5eef92b47f0898cef8a01668d5fe10715705e89c9cb1b81bL22-R22) [[2]](diffhunk://#diff-67b9304a1d7410bb5eef92b47f0898cef8a01668d5fe10715705e89c9cb1b81bL70-R70) [[3]](diffhunk://#diff-67b9304a1d7410bb5eef92b47f0898cef8a01668d5fe10715705e89c9cb1b81bL83-L84) [[4]](diffhunk://#diff-67b9304a1d7410bb5eef92b47f0898cef8a01668d5fe10715705e89c9cb1b81bR300-R305) [[5]](diffhunk://#diff-67b9304a1d7410bb5eef92b47f0898cef8a01668d5fe10715705e89c9cb1b81bL322-R331)

These changes collectively improve code quality, test coverage, and future maintainability.