### PR TITLE
Feature/mauricio/artwork domain tests

### DIFF
--- a/src/main/java/br/edu/ufpel/rokamoka/controller/ArtworkController.java
+++ b/src/main/java/br/edu/ufpel/rokamoka/controller/ArtworkController.java
@@ -15,7 +15,14 @@ import lombok.RequiredArgsConstructor;
 import org.apache.coyote.BadRequestException;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 @Tag(name = "Obra", description = "API para operações de CRUD em obras")
@@ -30,15 +37,17 @@ public class ArtworkController extends RokaMokaController {
     @Operation(summary = "Buscar obra por ID", description = "Retorna uma obra com base no ID informado")
     @GetMapping("/{id}")
     public ResponseEntity<ApiResponseWrapper<ArtworkOutputDTO>> findById(@PathVariable Long id) throws RokaMokaContentNotFoundException {
-        Artwork artwork = artworkService.findById(id);
-        return success(this.artworkRepository.createFullArtworkInfo(artwork.getId()));
+        Artwork artwork = this.artworkService.findById(id);
+        ArtworkOutputDTO dto = this.artworkRepository.createFullArtworkInfo(artwork.getId());
+        return this.success(dto);
     }
 
     @Operation(summary = "Obter informações da obra via QR code", description = "Retorna uma obra com base no QR code informado")
     @GetMapping("/{qrcode}")
     public ResponseEntity<ApiResponseWrapper<ArtworkOutputDTO>> getArtworkByQrCode(@PathVariable String qrcode) throws RokaMokaContentNotFoundException {
-        Artwork artwork = artworkService.getByQrCodeOrThrow(qrcode);
-        return success(this.artworkRepository.createFullArtworkInfo(artwork.getId()));
+        Artwork artwork = this.artworkService.getByQrCodeOrThrow(qrcode);
+        ArtworkOutputDTO dto = this.artworkRepository.createFullArtworkInfo(artwork.getId());
+        return this.success(dto);
     }
 
     @Operation(summary = "Upload de uma image em uma obra", description = "Faz upload de uma image, caso já exista estoura um erro")
@@ -48,7 +57,7 @@ public class ArtworkController extends RokaMokaController {
             throw new BadRequestException("É necessário enviar uma imagem");
         }
         this.artworkService.addImage(artworkId, image);
-        return success();
+        return this.success();
     }
 
     @Operation(summary = "Criar nova obra", description = "Cria uma nova obra com os dados fornecidos")
@@ -56,14 +65,14 @@ public class ArtworkController extends RokaMokaController {
     public ResponseEntity<ApiResponseWrapper<ArtworkOutputDTO>> create(@PathVariable Long exhibitionId,
                                                                        @ModelAttribute ArtworkInputDTO artworkDTO) throws RokaMokaContentNotFoundException {
         Artwork artwork = this.artworkService.create(exhibitionId, artworkDTO);
-        return success(new ArtworkOutputDTO(artwork));
+        return this.success(new ArtworkOutputDTO(artwork));
     }
 
     @Operation(summary = "Deletar obra", description = "Remove uma obra com base no ID informado")
     @DeleteMapping("/{id}")
     public ResponseEntity<ApiResponseWrapper<ArtworkOutputDTO>> deletar(@PathVariable Long id) throws RokaMokaContentNotFoundException {
-        var artwork = artworkService.findById(id);
-        artworkService.deleteById(id);
-        return success(new ArtworkOutputDTO(artwork));
+        var artwork = this.artworkService.findById(id);
+        this.artworkService.deleteById(id);
+        return this.success(new ArtworkOutputDTO(artwork));
     }
 }

--- a/src/main/java/br/edu/ufpel/rokamoka/service/artwork/ArtworkService.java
+++ b/src/main/java/br/edu/ufpel/rokamoka/service/artwork/ArtworkService.java
@@ -62,6 +62,7 @@ public class ArtworkService implements IArtworkService {
         Exhibition exhibition = this.exhibitionRepository.findById(exhibitionId).orElseThrow(RokaMokaContentNotFoundException::new);
         Artwork artwork = Artwork.builder()
                 .nome(artworkInputDTO.nome())
+                .descricao(artworkInputDTO.descricao())
                 .nomeArtista(artworkInputDTO.nomeArtista())
                 .link(artworkInputDTO.link())
                 .qrCode(artworkInputDTO.qrCode())

--- a/src/main/java/br/edu/ufpel/rokamoka/service/artwork/ArtworkService.java
+++ b/src/main/java/br/edu/ufpel/rokamoka/service/artwork/ArtworkService.java
@@ -24,25 +24,25 @@ import java.util.Optional;
 @AllArgsConstructor
 public class ArtworkService implements IArtworkService {
 
-    private final ArtworkRepository obraRepository;
+    private final ArtworkRepository artworkRepository;
     private final IIMageService imageService;
     private final ExhibitionRepository exhibitionRepository;
 
     @Override
     public List<Artwork> findAll() {
-        return obraRepository.findAll();
+        return this.artworkRepository.findAll();
     }
 
     @Override
     public Artwork findById(Long id) throws RokaMokaContentNotFoundException {
-        return obraRepository.findById(id).orElseThrow(RokaMokaContentNotFoundException::new);
+        return this.artworkRepository.findById(id).orElseThrow(RokaMokaContentNotFoundException::new);
     }
 
     @Override
     public Optional<Artwork> findByQrCode(String qrCode) {
         log.info("Buscando por obra usando qrCode: {}", qrCode);
 
-        Optional<Artwork> maybeArtwork = obraRepository.findByQrCode(qrCode);
+        Optional<Artwork> maybeArtwork = this.artworkRepository.findByQrCode(qrCode);
         maybeArtwork.ifPresentOrElse(
                 a -> log.info("Encontrou {}", a),
                 () -> log.info("Obra não existe!"));
@@ -68,21 +68,21 @@ public class ArtworkService implements IArtworkService {
                 .images(this.imageService.upload(artworkInputDTO.image()))
                 .exhibition(exhibition)
                 .build();
-        return obraRepository.save(artwork);
+        return this.artworkRepository.save(artwork);
     }
 
     @Override
     public void deleteById(Long id) {
-        obraRepository.deleteById(id);
+        this.artworkRepository.deleteById(id);
     }
 
     @Override
     public void addImage(Long artworkId, MultipartFile image) throws RokaMokaContentNotFoundException, RokaMokaForbiddenException {
-        var obra = this.obraRepository.findByIdWithinImage(artworkId).orElseThrow(RokaMokaContentNotFoundException::new);
+        var obra = this.artworkRepository.findByIdWithinImage(artworkId).orElseThrow(RokaMokaContentNotFoundException::new);
         if (!obra.getImages().isEmpty()) {
             throw new RokaMokaForbiddenException("Já existe uma imagem associada a essa obra");
         }
         obra.setImages(this.imageService.upload(image));
-        this.obraRepository.save(obra);
+        this.artworkRepository.save(obra);
     }
 }

--- a/src/test/java/br/edu/ufpel/rokamoka/controller/ArtworkControllerTest.java
+++ b/src/test/java/br/edu/ufpel/rokamoka/controller/ArtworkControllerTest.java
@@ -31,8 +31,11 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 /**
+ * Unit tests for the {@link ArtworkController} class, which is responsible for handling artwork-related endpoints.
  *
  * @author MauricioMucci
+ * @see IArtworkService
+ * @see ArtworkRepository
  */
 @ExtendWith(MockitoExtension.class)
 class ArtworkControllerTest implements ControllerResponseValidator {

--- a/src/test/java/br/edu/ufpel/rokamoka/controller/ArtworkControllerTest.java
+++ b/src/test/java/br/edu/ufpel/rokamoka/controller/ArtworkControllerTest.java
@@ -1,0 +1,258 @@
+package br.edu.ufpel.rokamoka.controller;
+
+import br.edu.ufpel.rokamoka.context.ApiResponseWrapper;
+import br.edu.ufpel.rokamoka.core.Artwork;
+import br.edu.ufpel.rokamoka.dto.artwork.input.ArtworkInputDTO;
+import br.edu.ufpel.rokamoka.dto.artwork.output.ArtworkOutputDTO;
+import br.edu.ufpel.rokamoka.exceptions.RokaMokaContentNotFoundException;
+import br.edu.ufpel.rokamoka.exceptions.RokaMokaForbiddenException;
+import br.edu.ufpel.rokamoka.repository.ArtworkRepository;
+import br.edu.ufpel.rokamoka.service.artwork.IArtworkService;
+import org.apache.coyote.BadRequestException;
+import org.instancio.Instancio;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.multipart.MultipartFile;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+/**
+ *
+ * @author MauricioMucci
+ */
+@ExtendWith(MockitoExtension.class)
+class ArtworkControllerTest implements ControllerResponseValidator {
+
+    @InjectMocks private ArtworkController artworkController;
+
+    @Mock private IArtworkService artworkService;
+    @Mock private ArtworkRepository artworkRepository;
+
+    //region findById
+    @Test
+    void findById_shouldReturnArtworkOutputDTO_whenArtworkExistsById() throws RokaMokaContentNotFoundException {
+        // Arrange
+        Artwork artwork = mock(Artwork.class);
+        ArtworkOutputDTO expected = Instancio.create(ArtworkOutputDTO.class);
+
+        when(this.artworkService.findById(anyLong())).thenReturn(artwork);
+        when(artwork.getId()).thenReturn(1L);
+        when(this.artworkRepository.createFullArtworkInfo(anyLong())).thenReturn(expected);
+
+        // Act
+        ResponseEntity<ApiResponseWrapper<ArtworkOutputDTO>> response = this.artworkController.findById(1L);
+
+        // Assert
+        this.assertExpectedResponse(response, expected);
+
+        verify(this.artworkService, times(1)).findById(anyLong());
+        verify(artwork, times(1)).getId();
+        verify(this.artworkRepository, times(1)).createFullArtworkInfo(anyLong());
+        verifyNoMoreInteractions(this.artworkService, artwork, this.artworkRepository);
+    }
+
+    @Test
+    void findById_shouldThrowRokaMokaContentNotFoundException_whenArtworkDoesNotExistById()
+    throws RokaMokaContentNotFoundException {
+        // Arrange
+        when(this.artworkService.findById(anyLong())).thenThrow(RokaMokaContentNotFoundException.class);
+
+        // Act & Assert
+        assertThrows(RokaMokaContentNotFoundException.class, () -> this.artworkController.findById(1L));
+
+        verify(this.artworkService, times(1)).findById(anyLong());
+        verifyNoMoreInteractions(this.artworkService);
+        verifyNoInteractions(this.artworkRepository);
+    }
+    //endregion
+
+    //region getArtworkByQrCode
+    @Test
+    void getArtworkByQrCode_shouldReturnArtworkOutputDTO_whenArtworkExistsByQrCode()
+    throws RokaMokaContentNotFoundException {
+        // Arrange
+        Artwork artwork = mock(Artwork.class);
+        ArtworkOutputDTO expected = Instancio.create(ArtworkOutputDTO.class);
+
+        when(this.artworkService.getByQrCodeOrThrow(anyString())).thenReturn(artwork);
+        when(artwork.getId()).thenReturn(1L);
+        when(this.artworkRepository.createFullArtworkInfo(anyLong())).thenReturn(expected);
+
+        // Act
+        ResponseEntity<ApiResponseWrapper<ArtworkOutputDTO>> response =
+                this.artworkController.getArtworkByQrCode("qrCode");
+
+        // Assert
+        this.assertExpectedResponse(response, expected);
+
+        verify(this.artworkService, times(1)).getByQrCodeOrThrow(anyString());
+        verify(this.artworkRepository, times(1)).createFullArtworkInfo(anyLong());
+        verifyNoMoreInteractions(this.artworkService, artwork, this.artworkRepository);
+    }
+
+    @Test
+    void getArtworkByQrCode_shouldThrowRokaMokaContentNotFoundException_whenArtworkDoesNotExistByQrCode()
+    throws RokaMokaContentNotFoundException {
+        // Arrange
+        when(this.artworkService.getByQrCodeOrThrow(anyString())).thenThrow(RokaMokaContentNotFoundException.class);
+
+        // Act & Assert
+        assertThrows(RokaMokaContentNotFoundException.class, () -> this.artworkController.getArtworkByQrCode("qrCode"));
+
+        verify(this.artworkService, times(1)).getByQrCodeOrThrow(anyString());
+        verifyNoMoreInteractions(this.artworkService);
+        verifyNoInteractions(this.artworkRepository);
+    }
+    //endregion
+
+    //region uploadImage
+    @Test
+    void uploadImage_shouldThrowBadRequestException_whenImageIsNull() {
+        assertThrows(BadRequestException.class, () -> this.artworkController.uploadImage(1L, null));
+        verifyNoInteractions(this.artworkService, this.artworkRepository);
+    }
+
+    @Test
+    void uploadImage_shouldThrowBadRequestException_whenImageIsEmpty() {
+        // Arrange
+        MultipartFile image = mock(MultipartFile.class);
+
+        when(image.isEmpty()).thenReturn(true);
+
+        // Act & Assert
+        assertThrows(BadRequestException.class, () -> this.artworkController.uploadImage(1L, image));
+
+        verifyNoMoreInteractions(this.artworkService, image);
+        verifyNoMoreInteractions(this.artworkRepository);
+    }
+
+    @Test
+    void uploadImage_shouldReturnVoidResponse_whenSuccessful()
+    throws BadRequestException, RokaMokaForbiddenException, RokaMokaContentNotFoundException {
+        // Arrange
+        MultipartFile image = mock(MultipartFile.class);
+
+        when(image.isEmpty()).thenReturn(false);
+
+        // Act
+        ResponseEntity<ApiResponseWrapper<Void>> response = this.artworkController.uploadImage(1L, image);
+
+        // Assert
+        this.assertVoidResponse(response);
+
+        verify(this.artworkService, times(1)).addImage(anyLong(), any(MultipartFile.class));
+        verifyNoMoreInteractions(this.artworkService, image);
+        verifyNoMoreInteractions(this.artworkRepository);
+    }
+
+    @Test
+    void uploadImage_shouldThrowRokaMokaForbiddenException_whenImageAlreadyExists()
+    throws RokaMokaContentNotFoundException, RokaMokaForbiddenException {
+        // Arrange
+        MultipartFile image = mock(MultipartFile.class);
+
+        when(image.isEmpty()).thenReturn(false);
+        doThrow(RokaMokaForbiddenException.class)
+                .when(this.artworkService)
+                .addImage(anyLong(), any(MultipartFile.class));
+
+        // Act & Assert
+        assertThrows(RokaMokaForbiddenException.class, () -> this.artworkController.uploadImage(1L, image));
+
+        verify(this.artworkService, times(1)).addImage(anyLong(), any(MultipartFile.class));
+        verifyNoMoreInteractions(this.artworkService, image);
+        verifyNoInteractions(this.artworkRepository);
+    }
+    //endregion
+
+    //region create
+    @Test
+    void create_shouldReturnArtworkOutputDTO_whenSuccessful() throws RokaMokaContentNotFoundException {
+        // Arrange
+        ArtworkInputDTO input = Instancio.create(ArtworkInputDTO.class);
+        Artwork artwork = mock(Artwork.class);
+        ArtworkOutputDTO expected = new ArtworkOutputDTO(artwork);
+
+        when(this.artworkService.create(anyLong(), any(ArtworkInputDTO.class))).thenReturn(artwork);
+
+        // Act
+        ResponseEntity<ApiResponseWrapper<ArtworkOutputDTO>> response = this.artworkController.create(1L, input);
+
+        // Assert
+        this.assertExpectedResponse(response, expected);
+
+        verify(this.artworkService, times(1)).create(anyLong(), any(ArtworkInputDTO.class));
+        verifyNoMoreInteractions(this.artworkService);
+        verifyNoMoreInteractions(this.artworkRepository);
+    }
+
+    @Test
+    void create_shouldThrowRokaMokaContentNotFoundException_whenExhibitionDoesNotExistById()
+    throws RokaMokaContentNotFoundException {
+        // Arrange
+        Long exhibitionId = 1L;
+        ArtworkInputDTO input = Instancio.create(ArtworkInputDTO.class);
+
+        when(this.artworkService.create(exhibitionId, input))
+                .thenThrow(RokaMokaContentNotFoundException.class);
+
+        // Act & Assert
+        assertThrows(RokaMokaContentNotFoundException.class,
+                () -> this.artworkController.create(exhibitionId, input));
+
+        verify(this.artworkService, times(1)).create(exhibitionId, input);
+        verifyNoMoreInteractions(this.artworkService);
+        verifyNoInteractions(this.artworkRepository);
+    }
+    //endregion
+
+    //region deletar
+    @Test
+    void deletar_shouldReturnArtworkOutputDTO_whenSuccessful() throws RokaMokaContentNotFoundException {
+        // Arrange
+        Artwork artwork = mock(Artwork.class);
+        ArtworkOutputDTO expected = new ArtworkOutputDTO(artwork);
+
+        when(this.artworkService.findById(anyLong())).thenReturn(artwork);
+
+        // Act
+        ResponseEntity<ApiResponseWrapper<ArtworkOutputDTO>> response = this.artworkController.deletar(1L);
+
+        // Assert
+        this.assertExpectedResponse(response, expected);
+
+        verify(this.artworkService, times(1)).findById(anyLong());
+        verify(this.artworkService, times(1)).deleteById(anyLong());
+        verifyNoMoreInteractions(this.artworkService);
+        verifyNoInteractions(this.artworkRepository);
+    }
+
+    @Test
+    void deletar_shouldThrowRokaMokaContentNotFoundException_whenArtworkDoesNotExistById()
+    throws RokaMokaContentNotFoundException {
+        // Arrange
+        when(this.artworkService.findById(anyLong())).thenThrow(RokaMokaContentNotFoundException.class);
+
+        // Act & Assert
+        assertThrows(RokaMokaContentNotFoundException.class, () -> this.artworkController.deletar(1L));
+
+        verify(this.artworkService, times(1)).findById(anyLong());
+        verifyNoMoreInteractions(this.artworkService);
+        verifyNoInteractions(this.artworkRepository);
+    }
+    //endregion
+}

--- a/src/test/java/br/edu/ufpel/rokamoka/service/artwork/ArtworkServiceTest.java
+++ b/src/test/java/br/edu/ufpel/rokamoka/service/artwork/ArtworkServiceTest.java
@@ -1,0 +1,312 @@
+package br.edu.ufpel.rokamoka.service.artwork;
+
+import br.edu.ufpel.rokamoka.core.Artwork;
+import br.edu.ufpel.rokamoka.core.Exhibition;
+import br.edu.ufpel.rokamoka.core.Image;
+import br.edu.ufpel.rokamoka.dto.artwork.input.ArtworkInputDTO;
+import br.edu.ufpel.rokamoka.exceptions.RokaMokaContentNotFoundException;
+import br.edu.ufpel.rokamoka.exceptions.RokaMokaForbiddenException;
+import br.edu.ufpel.rokamoka.repository.ArtworkRepository;
+import br.edu.ufpel.rokamoka.repository.ExhibitionRepository;
+import br.edu.ufpel.rokamoka.service.MockRepository;
+import br.edu.ufpel.rokamoka.service.MockUserSession;
+import br.edu.ufpel.rokamoka.service.image.IIMageService;
+import org.instancio.Instancio;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static org.instancio.Select.field;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+/**
+ *
+ * @author MauricioMucci
+ */
+@ExtendWith(MockitoExtension.class)
+class ArtworkServiceTest implements MockUserSession, MockRepository<Artwork> {
+
+    @InjectMocks private ArtworkService artworkService;
+
+    @Mock private ArtworkRepository artworkRepository;
+    @Mock private ExhibitionRepository exhibitionRepository;
+
+    @Mock private IIMageService imageService;
+
+    @Captor private ArgumentCaptor<Artwork> artworkCaptor;
+
+    //region findAll
+    static Stream<Arguments> buildFindAllInput() {
+        return Stream.of(Arguments.of(Collections.emptyList()), Arguments.of(Instancio.ofList(Artwork.class).create()));
+    }
+
+    @ParameterizedTest
+    @MethodSource("buildFindAllInput")
+    void findAll_shouldReturnListOfArtwork_whenCalled(List<Artwork> artworks) {
+        // Arrange
+        when(this.artworkRepository.findAll()).thenReturn(artworks);
+
+        // Act
+        List<Artwork> actual = this.artworkService.findAll();
+
+        // Assert
+        assertNotNull(actual);
+        if (artworks.isEmpty()) {
+            assertTrue(actual.isEmpty());
+            return;
+        }
+        assertEquals(artworks.size(), actual.size());
+
+        verify(this.artworkRepository).findAll();
+        verifyNoInteractions(this.exhibitionRepository, this.imageService);
+    }
+    //endregion
+
+    //region findById
+    @Test
+    void findById_shouldReturnArtwork_whenArtworkExistsById() throws RokaMokaContentNotFoundException {
+        // Arrange
+        Artwork expected = Instancio.create(Artwork.class);
+
+        when(this.artworkRepository.findById(anyLong())).thenReturn(Optional.of(expected));
+
+        // Act
+        Artwork actual = this.artworkService.findById(expected.getId());
+
+        // Assert
+        assertEquals(expected, actual);
+
+        verify(this.artworkRepository).findById(anyLong());
+        verifyNoInteractions(this.exhibitionRepository, this.imageService);
+    }
+
+    @Test
+    void findById_shouldThrowRokaMokaContentNotFoundException_whenArtworkDoesNotExistById() {
+        // Arrange
+        when(this.artworkRepository.findById(anyLong())).thenReturn(Optional.empty());
+
+        // Act & Assert
+        assertThrows(RokaMokaContentNotFoundException.class, () -> this.artworkService.findById(1L));
+
+        verify(this.artworkRepository).findById(anyLong());
+        verifyNoInteractions(this.exhibitionRepository, this.imageService);
+    }
+    //endregion
+
+    //region findByQrCode
+    @Test
+    void findByQrCode_shouldReturnArtwork_whenArtworkExistByQrCode() {
+        // Arrange
+        when(this.artworkRepository.findByQrCode(anyString())).thenReturn(Optional.of(mock(Artwork.class)));
+
+        // Act
+        Optional<Artwork> actual = this.artworkService.findByQrCode("qrCode");
+
+        // Assert
+        assertNotNull(actual);
+        assertTrue(actual.isPresent());
+
+        verify(this.artworkRepository, times(1)).findByQrCode(anyString());
+        verifyNoMoreInteractions(this.artworkRepository);
+        verifyNoInteractions(this.exhibitionRepository, this.imageService);
+    }
+
+    @Test
+    void findByQrCode_shouldReturnEmpty_whenArtworkDoesNotExistByQrCode() {
+        // Arrange
+        when(this.artworkRepository.findByQrCode(anyString())).thenReturn(Optional.empty());
+
+        // Act
+        Optional<Artwork> actual = this.artworkService.findByQrCode("qrCode");
+
+        // Assert
+        assertNotNull(actual);
+        assertTrue(actual.isEmpty());
+
+        verify(this.artworkRepository, times(1)).findByQrCode(anyString());
+        verifyNoMoreInteractions(this.artworkRepository);
+        verifyNoInteractions(this.exhibitionRepository, this.imageService);
+    }
+    //endregion
+
+    //region getByQrCodeOrThrow
+    @Test
+    void getByQrCodeOrThrow_shouldReturnArtwork_whenArtworkExistsByQrCode() throws RokaMokaContentNotFoundException {
+        // Arrange
+        String qrCode = "qrCode";
+        Artwork expected = Instancio.of(Artwork.class).set(field(Artwork::getQrCode), qrCode).create();
+
+        when(this.artworkRepository.findByQrCode(anyString())).thenReturn(Optional.of(expected));
+
+        // Act
+        Artwork actual = this.artworkService.getByQrCodeOrThrow(qrCode);
+
+        // Assert
+        assertEquals(expected, actual);
+
+        verify(this.artworkRepository, times(1)).findByQrCode(anyString());
+        verifyNoMoreInteractions(this.artworkRepository);
+        verifyNoInteractions(this.exhibitionRepository, this.imageService);
+    }
+
+    @Test
+    void getByQrCodeOrThrow_shouldThrowRokaMokaContentNotFoundException_whenArtworkDoesNotExistByQrCode() {
+        // Arrange
+        when(this.artworkRepository.findByQrCode(anyString())).thenReturn(Optional.empty());
+
+        // Act & Assert
+        assertThrows(RokaMokaContentNotFoundException.class, () -> this.artworkService.getByQrCodeOrThrow("qrCode"));
+
+        verify(this.artworkRepository, times(1)).findByQrCode(anyString());
+        verifyNoMoreInteractions(this.artworkRepository);
+        verifyNoInteractions(this.exhibitionRepository, this.imageService);
+    }
+    //endregion
+
+    //region create
+    @Test
+    void create_shouldReturnNewArtwork_whenInputIsValid() throws RokaMokaContentNotFoundException {
+        // Arrange
+        Exhibition exhibition = Instancio.create(Exhibition.class);
+        ArtworkInputDTO input = Instancio.create(ArtworkInputDTO.class);
+
+        when(this.exhibitionRepository.findById(anyLong())).thenReturn(Optional.of(exhibition));
+        when(this.imageService.upload(input.image())).thenReturn(Instancio.ofSet(Image.class).create());
+        when(this.artworkRepository.save(any(Artwork.class))).thenAnswer(
+                inv -> this.mockRepositorySave(inv.getArgument(0)));
+
+        // Act
+        Artwork actual = this.artworkService.create(exhibition.getId(), input);
+
+        // Assert
+        assertNotNull(actual);
+        assertNotNull(actual.getId());
+        assertEquals(exhibition, actual.getExhibition());
+        assertEquals(input.nome(), actual.getNome());
+        assertEquals(input.descricao(), actual.getDescricao());
+        assertEquals(input.nomeArtista(), actual.getNomeArtista());
+        assertEquals(input.link(), actual.getLink());
+        assertEquals(input.qrCode(), actual.getQrCode());
+
+        verify(this.exhibitionRepository, times(1)).findById(anyLong());
+        verify(this.artworkRepository, times(1)).save(any(Artwork.class));
+        verifyNoMoreInteractions(this.exhibitionRepository, this.artworkRepository);
+    }
+
+    @Test
+    void create_shouldThrowRokaMokaContentNotFoundException_whenExhibitionDoesNotExistById() {
+        // Arrange
+        Long exhibitionId = 1L;
+        ArtworkInputDTO input = Instancio.create(ArtworkInputDTO.class);
+
+        when(this.exhibitionRepository.findById(anyLong())).thenReturn(Optional.empty());
+
+        // Act & Assert
+        assertThrows(RokaMokaContentNotFoundException.class, () -> this.artworkService.create(exhibitionId, input));
+
+        verify(this.exhibitionRepository, times(1)).findById(anyLong());
+        verifyNoMoreInteractions(this.exhibitionRepository);
+        verifyNoInteractions(this.artworkRepository, this.imageService);
+    }
+    //endregion
+
+    //region deleteById
+    @Test
+    void deleteById_shouldDeleteArtwork_whenCalled() {
+        this.artworkService.deleteById(1L);
+
+        verify(this.artworkRepository, times(1)).deleteById(anyLong());
+        verifyNoMoreInteractions(this.artworkRepository);
+        verifyNoInteractions(this.exhibitionRepository, this.imageService);
+    }
+    //endregion
+
+    //region addImage
+    @Test
+    void addImage_shouldUploadImage_whenImageIsValid()
+    throws RokaMokaContentNotFoundException, RokaMokaForbiddenException {
+        // Arrange
+        Artwork artwork = Instancio.of(Artwork.class)
+                .set(field(Artwork::getId), 1L)
+                .set(field(Artwork::getImages), Collections.emptySet())
+                .create();
+        Set<Image> images = Instancio.ofSet(Image.class).create();
+
+        when(this.artworkRepository.findByIdWithinImage(anyLong())).thenReturn(Optional.of(artwork));
+        when(this.imageService.upload(any(MultipartFile.class))).thenReturn(images);
+        when(this.artworkRepository.save(any(Artwork.class))).thenAnswer(
+                inv -> this.mockRepositorySave(inv.getArgument(0)));
+
+        // Act
+        this.artworkService.addImage(1L, mock(MultipartFile.class));
+
+        // Assert
+        verify(this.artworkRepository, times(1)).findByIdWithinImage(anyLong());
+        verify(this.imageService, times(1)).upload(any(MultipartFile.class));
+        verify(this.artworkRepository, times(1)).save(this.artworkCaptor.capture());
+        verifyNoMoreInteractions(this.artworkRepository, this.imageService);
+        verifyNoInteractions(this.exhibitionRepository);
+
+        Artwork actual = this.artworkCaptor.getValue();
+        assertNotNull(actual);
+        assertEquals(images, actual.getImages());
+    }
+
+    @Test
+    void addImage_shouldThrowRokaMokaContentNotFoundException_whenIdDoesNotExistWithinImage() {
+        // Arrange
+        when(this.artworkRepository.findByIdWithinImage(anyLong())).thenReturn(Optional.empty());
+
+        // Act & Assert
+        assertThrows(RokaMokaContentNotFoundException.class,
+                () -> this.artworkService.addImage(1L, mock(MultipartFile.class)));
+
+        verify(this.artworkRepository, times(1)).findByIdWithinImage(anyLong());
+        verifyNoMoreInteractions(this.artworkRepository);
+        verifyNoInteractions(this.exhibitionRepository, this.imageService);
+    }
+
+    @Test
+    void addImage_shouldThrowRokaMokaForbiddenException_whenArtworkAlreadyContainsImage() {
+        // Arrange
+        Artwork artwork = mock(Artwork.class);
+
+        when(this.artworkRepository.findByIdWithinImage(anyLong())).thenReturn(Optional.of(artwork));
+        when(artwork.getImages()).thenReturn(Set.of(new Image()));
+
+        // Act & Assert
+        assertThrows(RokaMokaForbiddenException.class,
+                () -> this.artworkService.addImage(1L, mock(MultipartFile.class)));
+
+        verify(this.artworkRepository, times(1)).findByIdWithinImage(anyLong());
+        verifyNoMoreInteractions(this.artworkRepository);
+        verifyNoInteractions(this.exhibitionRepository, this.imageService);
+    }
+    //endregion
+}

--- a/src/test/java/br/edu/ufpel/rokamoka/service/artwork/ArtworkServiceTest.java
+++ b/src/test/java/br/edu/ufpel/rokamoka/service/artwork/ArtworkServiceTest.java
@@ -46,8 +46,12 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 /**
+ * Unit tests for the {@link ArtworkService} class, which is responsible for handling artwork-related API operations.
  *
  * @author MauricioMucci
+ * @see ArtworkRepository
+ * @see ExhibitionRepository
+ * @see IIMageService
  */
 @ExtendWith(MockitoExtension.class)
 class ArtworkServiceTest implements MockUserSession, MockRepository<Artwork> {


### PR DESCRIPTION
This pull request improves the consistency and testability of the `ArtworkController` and its service layer. The main changes include refactoring for clearer naming and dependency usage in `ArtworkService`, standardizing method calls in `ArtworkController`, and introducing comprehensive unit tests for the controller.

### Refactoring and Code Consistency

* Renamed the `obraRepository` field to `artworkRepository` throughout `ArtworkService` for clarity and consistency, and updated all usages accordingly. [[1]](diffhunk://#diff-a79b25163f18e6e389b12d0ccac3ed573d2097662e49bd7eeacded0dcc47464fL27-R45) [[2]](diffhunk://#diff-a79b25163f18e6e389b12d0ccac3ed573d2097662e49bd7eeacded0dcc47464fR65-R87)
* Standardized usage of `this.` for member accesses in both `ArtworkController` and `ArtworkService`, improving code readability and consistency. [[1]](diffhunk://#diff-64a24f60c6c734c0125a4df640a70a39d7d742178b914c44ff3d92410060eeeeL33-R50) [[2]](diffhunk://#diff-64a24f60c6c734c0125a4df640a70a39d7d742178b914c44ff3d92410060eeeeL51-R76) [[3]](diffhunk://#diff-a79b25163f18e6e389b12d0ccac3ed573d2097662e49bd7eeacded0dcc47464fL27-R45) [[4]](diffhunk://#diff-a79b25163f18e6e389b12d0ccac3ed573d2097662e49bd7eeacded0dcc47464fR65-R87)

### Controller Improvements

* Explicitly imported only the required Spring annotations in `ArtworkController` for better clarity and maintainability.
* Updated controller methods to use `this.success()` for response wrapping, ensuring a uniform response structure. [[1]](diffhunk://#diff-64a24f60c6c734c0125a4df640a70a39d7d742178b914c44ff3d92410060eeeeL33-R50) [[2]](diffhunk://#diff-64a24f60c6c734c0125a4df640a70a39d7d742178b914c44ff3d92410060eeeeL51-R76)

### Testing

* Added a new test class `ArtworkControllerTest` with comprehensive unit tests covering all main controller endpoints and edge cases, significantly improving test coverage and reliability.