### PR TITLE
Unit Tests for Permission Requests

### DIFF
--- a/src/main/java/br/edu/ufpel/rokamoka/controller/RequestPermissionController.java
+++ b/src/main/java/br/edu/ufpel/rokamoka/controller/RequestPermissionController.java
@@ -5,7 +5,7 @@ import br.edu.ufpel.rokamoka.core.RoleEnum;
 import br.edu.ufpel.rokamoka.dto.permission.output.PermissionRequestStatusDTO;
 import br.edu.ufpel.rokamoka.exceptions.RokaMokaContentDuplicatedException;
 import br.edu.ufpel.rokamoka.exceptions.RokaMokaContentNotFoundException;
-import br.edu.ufpel.rokamoka.service.implementation.RequestPermissionService;
+import br.edu.ufpel.rokamoka.service.IRequestPermissionService;
 import br.edu.ufpel.rokamoka.wrapper.RokaMokaController;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -25,7 +25,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class RequestPermissionController extends RokaMokaController {
 
-    private final RequestPermissionService requestPermissionService;
+    private final IRequestPermissionService requestPermissionService;
 
     @Operation(summary = "Solicitar acesso como curador")
     @PostMapping(value = "/curator", produces = MediaType.APPLICATION_JSON_VALUE)

--- a/src/main/java/br/edu/ufpel/rokamoka/controller/RequestPermissionController.java
+++ b/src/main/java/br/edu/ufpel/rokamoka/controller/RequestPermissionController.java
@@ -13,7 +13,11 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Solicitação de Acesso", description = "API para o usuário soliciar acesso como Curador ou Pesquisador")
 @RestController
@@ -25,22 +29,27 @@ public class RequestPermissionController extends RokaMokaController {
 
     @Operation(summary = "Solicitar acesso como curador")
     @PostMapping(value = "/curator", produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<ApiResponseWrapper<PermissionRequestStatusDTO>> createPermissionRequestCurator(Authentication authentication)
-            throws RokaMokaContentNotFoundException, RokaMokaContentDuplicatedException {
-        return success(requestPermissionService.createRequest(authentication.getName(), RoleEnum.CURATOR));
+    public ResponseEntity<ApiResponseWrapper<PermissionRequestStatusDTO>> createPermissionRequestCurator(
+            Authentication authentication) throws RokaMokaContentNotFoundException, RokaMokaContentDuplicatedException {
+        PermissionRequestStatusDTO request =
+                this.requestPermissionService.createRequest(authentication.getName(), RoleEnum.CURATOR);
+        return this.success(request);
     }
 
     @Operation(summary = "Solicitar acesso como Pesquisador")
     @PostMapping(value = "/researcher", produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<ApiResponseWrapper<PermissionRequestStatusDTO>> createPermissionRequestResearcher(Authentication authentication)
-            throws RokaMokaContentNotFoundException, RokaMokaContentDuplicatedException {
-        return success(requestPermissionService.createRequest(authentication.getName(), RoleEnum.RESEARCHER));
+    public ResponseEntity<ApiResponseWrapper<PermissionRequestStatusDTO>> createPermissionRequestResearcher(
+            Authentication authentication) throws RokaMokaContentNotFoundException, RokaMokaContentDuplicatedException {
+        PermissionRequestStatusDTO request =
+                this.requestPermissionService.createRequest(authentication.getName(), RoleEnum.RESEARCHER);
+        return this.success(request);
     }
 
     @Operation(summary = "Adquirir status atual da solicitação")
     @GetMapping(value = "/status/{permissionId}", produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<ApiResponseWrapper<PermissionRequestStatusDTO>> getPermissionRequestStatus(@PathVariable Long permissionId)
-            throws RokaMokaContentNotFoundException {
-        return success(requestPermissionService.getPermissionRequestStatus(permissionId));
+    public ResponseEntity<ApiResponseWrapper<PermissionRequestStatusDTO>> getPermissionRequestStatus(
+            @PathVariable Long permissionId) throws RokaMokaContentNotFoundException {
+        PermissionRequestStatusDTO dto = this.requestPermissionService.getPermissionRequestStatus(permissionId);
+        return this.success(dto);
     }
 }

--- a/src/main/java/br/edu/ufpel/rokamoka/dto/permission/output/PermissionRequestStatusDTO.java
+++ b/src/main/java/br/edu/ufpel/rokamoka/dto/permission/output/PermissionRequestStatusDTO.java
@@ -1,7 +1,12 @@
 package br.edu.ufpel.rokamoka.dto.permission.output;
 
+import br.edu.ufpel.rokamoka.core.PermissionReq;
 import br.edu.ufpel.rokamoka.core.RequestStatus;
 import br.edu.ufpel.rokamoka.core.RoleEnum;
 
 public record PermissionRequestStatusDTO(Long id, RequestStatus status, RoleEnum targetRole) {
+
+    public PermissionRequestStatusDTO(PermissionReq request) {
+        this(request.getId(), request.getStatus(), request.getTargetRole().getName());
+    }
 }

--- a/src/main/java/br/edu/ufpel/rokamoka/service/implementation/RequestPermissionService.java
+++ b/src/main/java/br/edu/ufpel/rokamoka/service/implementation/RequestPermissionService.java
@@ -10,8 +10,8 @@ import br.edu.ufpel.rokamoka.exceptions.RokaMokaContentDuplicatedException;
 import br.edu.ufpel.rokamoka.exceptions.RokaMokaContentNotFoundException;
 import br.edu.ufpel.rokamoka.repository.PermissionReqRepository;
 import br.edu.ufpel.rokamoka.repository.RoleRepository;
-import br.edu.ufpel.rokamoka.repository.UserRepository;
 import br.edu.ufpel.rokamoka.service.IRequestPermissionService;
+import br.edu.ufpel.rokamoka.service.user.IUserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -20,14 +20,14 @@ import org.springframework.stereotype.Service;
 public class RequestPermissionService implements IRequestPermissionService {
 
     private final PermissionReqRepository permissionReqRepository;
-    private final UserRepository userRepository;
     private final RoleRepository roleRepository;
+
+    private final IUserService userService;
 
     @Override
     public PermissionRequestStatusDTO createRequest(String userName, RoleEnum role)
     throws RokaMokaContentNotFoundException, RokaMokaContentDuplicatedException {
-        User requester = this.userRepository.findByNome(userName)
-                .orElseThrow(() -> new RokaMokaContentNotFoundException("Usuário não encontrado"));
+        User requester = this.userService.getByNome(userName);
 
         Role targetRole = this.roleRepository.findByName(role);
 

--- a/src/main/java/br/edu/ufpel/rokamoka/service/implementation/RequestPermissionService.java
+++ b/src/main/java/br/edu/ufpel/rokamoka/service/implementation/RequestPermissionService.java
@@ -1,6 +1,10 @@
 package br.edu.ufpel.rokamoka.service.implementation;
 
-import br.edu.ufpel.rokamoka.core.*;
+import br.edu.ufpel.rokamoka.core.PermissionReq;
+import br.edu.ufpel.rokamoka.core.RequestStatus;
+import br.edu.ufpel.rokamoka.core.Role;
+import br.edu.ufpel.rokamoka.core.RoleEnum;
+import br.edu.ufpel.rokamoka.core.User;
 import br.edu.ufpel.rokamoka.dto.permission.output.PermissionRequestStatusDTO;
 import br.edu.ufpel.rokamoka.exceptions.RokaMokaContentDuplicatedException;
 import br.edu.ufpel.rokamoka.exceptions.RokaMokaContentNotFoundException;
@@ -20,16 +24,15 @@ public class RequestPermissionService implements IRequestPermissionService {
     private final RoleRepository roleRepository;
 
     @Override
-    public PermissionRequestStatusDTO createRequest(String userName, RoleEnum role) throws RokaMokaContentNotFoundException, RokaMokaContentDuplicatedException {
-        User requester = userRepository.findByNome(userName)
+    public PermissionRequestStatusDTO createRequest(String userName, RoleEnum role)
+    throws RokaMokaContentNotFoundException, RokaMokaContentDuplicatedException {
+        User requester = this.userRepository.findByNome(userName)
                 .orElseThrow(() -> new RokaMokaContentNotFoundException("Usuário não encontrado"));
 
-        Role targetRole = roleRepository.findByName(role);
+        Role targetRole = this.roleRepository.findByName(role);
 
-        if (permissionReqRepository.existsByRequesterAndStatusAndTargetRole(
-                requester,
-                RequestStatus.PENDING,
-                targetRole)) {
+        if (this.permissionReqRepository.existsByRequesterAndStatusAndTargetRole(
+                requester, RequestStatus.PENDING, targetRole)) {
             throw new RokaMokaContentDuplicatedException("Já existe uma solicitação pendente para este usuário e perfil");
         }
 
@@ -38,24 +41,16 @@ public class RequestPermissionService implements IRequestPermissionService {
                 .status(RequestStatus.PENDING)
                 .targetRole(targetRole)
                 .build();
+        PermissionReq savedRequest = this.permissionReqRepository.save(permissionReq);
 
-        PermissionReq savedRequest = permissionReqRepository.save(permissionReq);
-
-        return new PermissionRequestStatusDTO(
-                savedRequest.getId(),
-                savedRequest.getStatus(),
-                savedRequest.getTargetRole().getName()
-        );
+        return new PermissionRequestStatusDTO(savedRequest);
     }
 
     @Override
-    public PermissionRequestStatusDTO getPermissionRequestStatus(Long permissionID) throws RokaMokaContentNotFoundException {
-        PermissionReq permissionReq = permissionReqRepository.findById(permissionID)
+    public PermissionRequestStatusDTO getPermissionRequestStatus(Long permissionID)
+    throws RokaMokaContentNotFoundException {
+        PermissionReq permissionReq = this.permissionReqRepository.findById(permissionID)
                 .orElseThrow(() -> new RokaMokaContentNotFoundException("Solicitação não encontrada"));
-        return new PermissionRequestStatusDTO(
-                permissionReq.getId(),
-                permissionReq.getStatus(),
-                permissionReq.getTargetRole().getName()
-        );
+        return new PermissionRequestStatusDTO(permissionReq);
     }
 }

--- a/src/main/java/br/edu/ufpel/rokamoka/service/user/IUserService.java
+++ b/src/main/java/br/edu/ufpel/rokamoka/service/user/IUserService.java
@@ -37,4 +37,6 @@ public interface IUserService {
     void updateRole(@NotNull User requester, Role role);
 
     UserOutputDTO getLoggedUserInformation() throws RokaMokaContentNotFoundException;
+
+    User getByNome(@NotNull String nome) throws RokaMokaContentNotFoundException;
 }

--- a/src/main/java/br/edu/ufpel/rokamoka/service/user/UserService.java
+++ b/src/main/java/br/edu/ufpel/rokamoka/service/user/UserService.java
@@ -178,6 +178,12 @@ public class UserService implements IUserService {
         return new UserOutputDTO(loggedUser, mokadexOutputDTO);
     }
 
+    @Override
+    public User getByNome(String nome) throws RokaMokaContentNotFoundException {
+        return this.userRepository.findByNome(nome)
+                .orElseThrow(() -> new RokaMokaContentNotFoundException("Usuário não encontrado"));
+    }
+
     private User findLoggedUser() throws RokaMokaContentNotFoundException {
         return this.userRepository
                 .findByNome(ServiceContext.getContext().getUser().getUsername())

--- a/src/test/java/br/edu/ufpel/rokamoka/controller/RequestPermissionControllerTest.java
+++ b/src/test/java/br/edu/ufpel/rokamoka/controller/RequestPermissionControllerTest.java
@@ -1,11 +1,24 @@
 package br.edu.ufpel.rokamoka.controller;
 
+import br.edu.ufpel.rokamoka.context.ApiResponseWrapper;
+import br.edu.ufpel.rokamoka.core.RoleEnum;
+import br.edu.ufpel.rokamoka.dto.permission.output.PermissionRequestStatusDTO;
+import br.edu.ufpel.rokamoka.exceptions.RokaMokaContentDuplicatedException;
+import br.edu.ufpel.rokamoka.exceptions.RokaMokaContentNotFoundException;
 import br.edu.ufpel.rokamoka.service.IRequestPermissionService;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * Unit tests for the {@link RequestPermissionController} class, which is responsible for handling
@@ -23,19 +36,153 @@ class RequestPermissionControllerTest implements ControllerResponseValidator {
 
     //region createPermissionRequestCurator
     @Test
-    void createPermissionRequestCurator() {
+    void createPermissionRequestCurator_shouldReturnPermissionRequestStatusDTO_whenSuccessful()
+    throws RokaMokaContentDuplicatedException, RokaMokaContentNotFoundException {
+        // Arrange
+        String username = "username";
+        Authentication authentication = mock(Authentication.class);
+        PermissionRequestStatusDTO request = mock(PermissionRequestStatusDTO.class);
+
+        when(authentication.getName()).thenReturn(username);
+        when(this.requestPermissionService.createRequest(username, RoleEnum.CURATOR)).thenReturn(request);
+
+        // Act
+        ResponseEntity<ApiResponseWrapper<PermissionRequestStatusDTO>> response =
+                this.requestPermissionController.createPermissionRequestCurator(authentication);
+
+        // Assert
+        this.assertExpectedResponse(response, request);
+
+        verify(this.requestPermissionService).createRequest(username, RoleEnum.CURATOR);
+    }
+
+    @Test
+    void createPermissionRequestCurator_shouldThrowRokaMokaContentNotFoundException_whenAnyEntityIsNotFound()
+    throws RokaMokaContentDuplicatedException, RokaMokaContentNotFoundException {
+        // Arrange
+        String username = "username";
+        Authentication authentication = mock(Authentication.class);
+
+        when(authentication.getName()).thenReturn(username);
+        when(this.requestPermissionService.createRequest(username, RoleEnum.CURATOR)).thenThrow(
+                RokaMokaContentNotFoundException.class);
+
+        // Act & Assert
+        assertThrows(RokaMokaContentNotFoundException.class,
+                () -> this.requestPermissionController.createPermissionRequestCurator(authentication));
+
+        verify(this.requestPermissionService).createRequest(username, RoleEnum.CURATOR);
+    }
+
+    @Test
+    void createPermissionRequestCurator_shouldThrowRokaMokaContentNotFoundException_whenRequestAlreadyExists()
+    throws RokaMokaContentDuplicatedException, RokaMokaContentNotFoundException {
+        // Arrange
+        String username = "username";
+        Authentication authentication = mock(Authentication.class);
+
+        when(authentication.getName()).thenReturn(username);
+        when(this.requestPermissionService.createRequest(username, RoleEnum.CURATOR)).thenThrow(
+                RokaMokaContentDuplicatedException.class);
+
+        // Act & Assert
+        assertThrows(RokaMokaContentDuplicatedException.class,
+                () -> this.requestPermissionController.createPermissionRequestCurator(authentication));
+
+        verify(this.requestPermissionService).createRequest(username, RoleEnum.CURATOR);
     }
     //endregion
 
     //region createPermissionRequestResearcher
     @Test
-    void createPermissionRequestResearcher() {
+    void createPermissionRequestResearcher_shouldReturnPermissionRequestStatusDTO_whenSuccessful()
+    throws RokaMokaContentDuplicatedException, RokaMokaContentNotFoundException {
+        // Arrange
+        String username = "username";
+        Authentication authentication = mock(Authentication.class);
+        PermissionRequestStatusDTO request = mock(PermissionRequestStatusDTO.class);
+
+        when(authentication.getName()).thenReturn(username);
+        when(this.requestPermissionService.createRequest(username, RoleEnum.RESEARCHER)).thenReturn(request);
+
+        // Act
+        ResponseEntity<ApiResponseWrapper<PermissionRequestStatusDTO>> response =
+                this.requestPermissionController.createPermissionRequestResearcher(authentication);
+
+        // Assert
+        this.assertExpectedResponse(response, request);
+
+        verify(this.requestPermissionService).createRequest(username, RoleEnum.RESEARCHER);
+    }
+
+    @Test
+    void createPermissionRequestResearcher_shouldThrowRokaMokaContentNotFoundException_whenAnyEntityIsNotFound()
+    throws RokaMokaContentDuplicatedException, RokaMokaContentNotFoundException {
+        // Arrange
+        String username = "username";
+        Authentication authentication = mock(Authentication.class);
+
+        when(authentication.getName()).thenReturn(username);
+        when(this.requestPermissionService.createRequest(username, RoleEnum.RESEARCHER)).thenThrow(
+                RokaMokaContentNotFoundException.class);
+
+        // Act & Assert
+        assertThrows(RokaMokaContentNotFoundException.class,
+                () -> this.requestPermissionController.createPermissionRequestResearcher(authentication));
+
+        verify(this.requestPermissionService).createRequest(username, RoleEnum.RESEARCHER);
+    }
+
+    @Test
+    void createPermissionRequestResearcher_shouldThrowRokaMokaContentNotFoundException_whenRequestAlreadyExists()
+    throws RokaMokaContentDuplicatedException, RokaMokaContentNotFoundException {
+        // Arrange
+        String username = "username";
+        Authentication authentication = mock(Authentication.class);
+
+        when(authentication.getName()).thenReturn(username);
+        when(this.requestPermissionService.createRequest(username, RoleEnum.RESEARCHER)).thenThrow(
+                RokaMokaContentDuplicatedException.class);
+
+        // Act & Assert
+        assertThrows(RokaMokaContentDuplicatedException.class,
+                () -> this.requestPermissionController.createPermissionRequestResearcher(authentication));
+
+        verify(this.requestPermissionService).createRequest(username, RoleEnum.RESEARCHER);
     }
     //endregion
 
     //region getPermissionRequestStatus
     @Test
-    void getPermissionRequestStatus() {
+    void getPermissionRequestStatus_shouldReturnPermissionRequestStatusDTO_whenSuccessful()
+    throws RokaMokaContentNotFoundException {
+        // Arrange
+        PermissionRequestStatusDTO request = mock(PermissionRequestStatusDTO.class);
+
+        when(this.requestPermissionService.getPermissionRequestStatus(anyLong())).thenReturn(request);
+
+        // Act
+        ResponseEntity<ApiResponseWrapper<PermissionRequestStatusDTO>> response =
+                this.requestPermissionController.getPermissionRequestStatus(anyLong());
+
+        // Assert
+        this.assertExpectedResponse(response, request);
+
+        verify(this.requestPermissionService).getPermissionRequestStatus(anyLong());
+    }
+
+    @Test
+    void getPermissionRequestStatus_shouldThrowRokaMokaContentNotFoundException_whenAnyEntityIsNotFound()
+    throws RokaMokaContentNotFoundException {
+        // Arrange
+        when(this.requestPermissionService.getPermissionRequestStatus(anyLong())).thenThrow(
+                RokaMokaContentNotFoundException.class);
+
+        // Act & Assert
+        assertThrows(RokaMokaContentNotFoundException.class,
+                () -> this.requestPermissionController.getPermissionRequestStatus(1L));
+
+        verify(this.requestPermissionService).getPermissionRequestStatus(anyLong());
     }
     //endregion
 }

--- a/src/test/java/br/edu/ufpel/rokamoka/controller/RequestPermissionControllerTest.java
+++ b/src/test/java/br/edu/ufpel/rokamoka/controller/RequestPermissionControllerTest.java
@@ -1,0 +1,41 @@
+package br.edu.ufpel.rokamoka.controller;
+
+import br.edu.ufpel.rokamoka.service.IRequestPermissionService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Unit tests for the {@link RequestPermissionController} class, which is responsible for handling
+ * permission-request-related endpoints.
+ *
+ * @author MauricioMucci
+ * @see IRequestPermissionService
+ */
+@ExtendWith(MockitoExtension.class)
+class RequestPermissionControllerTest implements ControllerResponseValidator {
+
+    @InjectMocks private RequestPermissionController requestPermissionController;
+
+    @Mock private IRequestPermissionService requestPermissionService;
+
+    //region createPermissionRequestCurator
+    @Test
+    void createPermissionRequestCurator() {
+    }
+    //endregion
+
+    //region createPermissionRequestResearcher
+    @Test
+    void createPermissionRequestResearcher() {
+    }
+    //endregion
+
+    //region getPermissionRequestStatus
+    @Test
+    void getPermissionRequestStatus() {
+    }
+    //endregion
+}

--- a/src/test/java/br/edu/ufpel/rokamoka/service/implementation/RequestPermissionServiceTest.java
+++ b/src/test/java/br/edu/ufpel/rokamoka/service/implementation/RequestPermissionServiceTest.java
@@ -1,0 +1,44 @@
+package br.edu.ufpel.rokamoka.service.implementation;
+
+import br.edu.ufpel.rokamoka.core.PermissionReq;
+import br.edu.ufpel.rokamoka.repository.PermissionReqRepository;
+import br.edu.ufpel.rokamoka.repository.RoleRepository;
+import br.edu.ufpel.rokamoka.service.MockRepository;
+import br.edu.ufpel.rokamoka.service.user.IUserService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Unit tests for the {@link RequestPermissionService} class, which is responsible for handling
+ * permission-request-related API operations.
+ *
+ * @author MauricioMucci
+ * @see PermissionReqRepository
+ * @see RoleRepository
+ * @see IUserService
+ */
+@ExtendWith(MockitoExtension.class)
+class RequestPermissionServiceTest implements MockRepository<PermissionReq> {
+
+    @InjectMocks private RequestPermissionService requestPermissionService;
+
+    @Mock private PermissionReqRepository permissionReqRepository;
+    @Mock private RoleRepository roleRepository;
+
+    @Mock private IUserService userService;
+
+    //region createRequest
+    @Test
+    void createRequest() {
+    }
+    //endregion
+
+    //region getPermissionRequestStatus
+    @Test
+    void getPermissionRequestStatus() {
+    }
+    //endregion
+}

--- a/src/test/java/br/edu/ufpel/rokamoka/service/implementation/RequestPermissionServiceTest.java
+++ b/src/test/java/br/edu/ufpel/rokamoka/service/implementation/RequestPermissionServiceTest.java
@@ -1,15 +1,39 @@
 package br.edu.ufpel.rokamoka.service.implementation;
 
 import br.edu.ufpel.rokamoka.core.PermissionReq;
+import br.edu.ufpel.rokamoka.core.RequestStatus;
+import br.edu.ufpel.rokamoka.core.Role;
+import br.edu.ufpel.rokamoka.core.RoleEnum;
+import br.edu.ufpel.rokamoka.core.User;
+import br.edu.ufpel.rokamoka.dto.permission.output.PermissionRequestStatusDTO;
+import br.edu.ufpel.rokamoka.exceptions.RokaMokaContentDuplicatedException;
+import br.edu.ufpel.rokamoka.exceptions.RokaMokaContentNotFoundException;
 import br.edu.ufpel.rokamoka.repository.PermissionReqRepository;
 import br.edu.ufpel.rokamoka.repository.RoleRepository;
 import br.edu.ufpel.rokamoka.service.MockRepository;
 import br.edu.ufpel.rokamoka.service.user.IUserService;
+import org.instancio.Instancio;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * Unit tests for the {@link RequestPermissionService} class, which is responsible for handling
@@ -30,15 +54,70 @@ class RequestPermissionServiceTest implements MockRepository<PermissionReq> {
 
     @Mock private IUserService userService;
 
+    @Captor private ArgumentCaptor<PermissionReq> requestCaptor;
+
     //region createRequest
-    @Test
-    void createRequest() {
+    @ParameterizedTest
+    @EnumSource(value = RoleEnum.class)
+    void createRequest_shouldSaveNewRequest_whenSuccessful(RoleEnum roleName)
+    throws RokaMokaContentNotFoundException, RokaMokaContentDuplicatedException {
+        // Arrange
+        User requester = mock(User.class);
+        Role targetRole = mock(Role.class);
+
+        when(this.userService.getByNome(anyString())).thenReturn(requester);
+        when(this.roleRepository.findByName(roleName)).thenReturn(targetRole);
+        when(this.permissionReqRepository.existsByRequesterAndStatusAndTargetRole(requester, RequestStatus.PENDING,
+                targetRole)).thenReturn(false);
+        when(this.permissionReqRepository.save(any(PermissionReq.class))).thenAnswer(
+                inv -> this.mockRepositorySave(inv.getArgument(0)));
+
+        // Act
+        PermissionRequestStatusDTO actual = this.requestPermissionService.createRequest("", roleName);
+
+        // Assert
+        verify(this.permissionReqRepository).save(this.requestCaptor.capture());
+
+        PermissionReq newRequest = this.requestCaptor.getValue();
+        this.assertOutputByPermissionReq(newRequest, actual);
+    }
+
+    private void assertOutputByPermissionReq(PermissionReq expected, PermissionRequestStatusDTO actual) {
+        assertNotNull(actual);
+        assertEquals(expected.getId(), actual.id());
+        assertEquals(expected.getStatus(), actual.status());
+        assertEquals(expected.getTargetRole().getName(), actual.targetRole());
     }
     //endregion
 
     //region getPermissionRequestStatus
     @Test
-    void getPermissionRequestStatus() {
+    void getPermissionRequestStatus_shouldReturnPermissionRequestStatusDTO_whenRequestExistsById()
+    throws RokaMokaContentNotFoundException {
+        // Arrange
+        PermissionReq foundById = Instancio.create(PermissionReq.class);
+
+        when(this.permissionReqRepository.findById(anyLong())).thenReturn(Optional.of(foundById));
+
+        // Act
+        PermissionRequestStatusDTO actual = this.requestPermissionService.getPermissionRequestStatus(foundById.getId());
+
+        // Assert
+        this.assertOutputByPermissionReq(foundById, actual);
+
+        verify(this.permissionReqRepository).findById(anyLong());
+    }
+
+    @Test
+    void getPermissionRequestStatus_shouldThrowRokaMokaContentNotFoundException_whenRequestDoesNotExistById() {
+        // Arrange
+        when(this.permissionReqRepository.findById(anyLong())).thenReturn(Optional.empty());
+
+        // Act & Assert
+        assertThrows(RokaMokaContentNotFoundException.class,
+                () -> this.requestPermissionService.getPermissionRequestStatus(1L));
+
+        verify(this.permissionReqRepository).findById(anyLong());
     }
     //endregion
 }


### PR DESCRIPTION
This pull request refactors the permission request flow to improve code modularity, testability, and maintainability. The main changes include introducing a service interface for permission requests, delegating user lookups to the user service, refactoring DTO construction, and adding comprehensive unit tests for the controller.

**Service layer refactoring and interface introduction:**

* Replaced direct usage of `RequestPermissionService` with the `IRequestPermissionService` interface in `RequestPermissionController`, and updated imports to use explicit Spring annotations for clarity.
* In `RequestPermissionService`, replaced direct repository access for user lookup with a new `IUserService#getByNome` method, promoting better separation of concerns and easier mocking for tests. [[1]](diffhunk://#diff-258e2e87922e7b5820ca047f805f241f8c5548df823cb03c34d3f082dea16451L19-R35) [[2]](diffhunk://#diff-4568c953f4fc0b16b6aec12c588a22e4bd2b0fe479b8fb207eb6c489b04fe641R40-R41) [[3]](diffhunk://#diff-0a33043c5869bcefb396592f6d281a29ac057fde82f27c3a11178f0275a6de89R181-R186)

**DTO and model improvements:**

* Refactored `PermissionRequestStatusDTO` to include a constructor that accepts a `PermissionReq` object, simplifying DTO creation and reducing code duplication. Updated service methods to use this constructor. [[1]](diffhunk://#diff-ac803b9ffdf74197fe81c542f466795a913074b9f826d2b465b75b8e7af74280R3-R11) [[2]](diffhunk://#diff-258e2e87922e7b5820ca047f805f241f8c5548df823cb03c34d3f082dea16451R44-R54)

**Testing enhancements:**

* Added a new test class `RequestPermissionControllerTest` with comprehensive unit tests for all controller endpoints, including success and failure scenarios, improving test coverage and reliability.